### PR TITLE
Fix invalid XML in solrconfig and schema

### DIFF
--- a/spec/dummy/solr/collection1/conf/schema.xml
+++ b/spec/dummy/solr/collection1/conf/schema.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 # The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government, 
 # and is licensed under the GNU General Public License, version 3.
@@ -7,7 +8,6 @@
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with

--- a/spec/dummy/solr/collection1/conf/solrconfig.xml
+++ b/spec/dummy/solr/collection1/conf/solrconfig.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--
 # The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government, 
 # and is licensed under the GNU General Public License, version 3.
@@ -6,8 +7,6 @@
 # Supplejack was created by DigitalNZ at the National Library of NZ and 
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 -->
-
-<?xml version="1.0" encoding="UTF-8" ?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Per the [XML spec restrictions](http://stackoverflow.com/a/1196485/1277323), nothing can precede the XML declaration in a file, including comments. This commit moves the Supplejack copyright notice after the XML declaration.

Note: without this change, the Solr core `collection1` does not get loaded properly.
