### PR TITLE
Fix for when set items point to deleted records

### DIFF
--- a/app/models/supplejack_api/interaction_models/record.rb
+++ b/app/models/supplejack_api/interaction_models/record.rb
@@ -34,6 +34,9 @@ module SupplejackApi
         Rails.logger.warn "[RecordInteraction] Field #{field} does not exist"
       end
 
+      # Creates one Interaction Model that contains set items in a set
+      #
+      # @param object [SupplejackApi::UserSet]
       def self.create_user_set(object)
         results = []
         unless object.set_items.empty?

--- a/app/models/supplejack_api/interaction_models/record.rb
+++ b/app/models/supplejack_api/interaction_models/record.rb
@@ -38,6 +38,7 @@ module SupplejackApi
         results = []
         unless object.set_items.empty?
           object.set_items.each do |item|
+            next if item.record.nil?
             record = SupplejackApi::Record.custom_find(item.record_id)
             if record
               result = record.send(@field)


### PR DESCRIPTION
Acceptance Criteria
=================
https://www.pivotaltracker.com/story/show/121259989

Background
=================

Basically the issue is that a set contains set items that point to records. If a record has a status of 'deleted' the set items record is nil. So when the record interaction models gets created, the mongo look up for the nil record 500's.

After talking with Dan what he would like done is simply to guard against this scenario when the results are created.

See basecamp for more details

https://basecamp.com/1723294/projects/8491945/messages/58848415#comment_427298122

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] All Tests are Passing
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Linters Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalnz/supplejack_api/21)
<!-- Reviewable:end -->
