### PR TITLE
Changes to allow sets created on dnz to be properly edited on kereru

### DIFF
--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -100,7 +100,7 @@ module SupplejackApi::Concerns::UserSet
       update_featured_set(new_attributes, user)
 
       self.attributes = new_attributes
-
+      # 
       save
     end
 

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -100,7 +100,7 @@ module SupplejackApi::Concerns::UserSet
       update_featured_set(new_attributes, user)
 
       self.attributes = new_attributes
-      # 
+
       save
     end
 

--- a/app/services/stories_api/v3/endpoints/story.rb
+++ b/app/services/stories_api/v3/endpoints/story.rb
@@ -28,12 +28,16 @@ module StoriesApi
         end
 
         def patch
+          Rails.logger.info 'Stories Issues'
           story = SupplejackApi::UserSet.custom_find(params[:id])
+          Rails.logger.info "Stories Issues: story #{story}"
           merge_patch = PerformMergePatch.new(::StoriesApi::V3::Schemas::Story, ::StoriesApi::V3::Presenters::Story.new)
           return create_error('StoryNotFound',
                               id: params[:id]) unless story.present?
 
           valid = merge_patch.call(story, params[:story])
+          Rails.logger.info "Stories Issues valid #{valid}"
+          Rails.logger.info "Stories Issues: message #{merge_patch.validation_errors}" unless valid
           return create_error('SchemaValidationError',
                               errors:  merge_patch.validation_errors) unless valid
 

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -11,7 +11,6 @@ module SupplejackApi
   describe UserSet do
 
     let(:user_set) { FactoryGirl.build(:user_set)}
-
     before(:each) do
       allow(user_set).to receive(:update_record)
       allow(user_set).to receive(:reindex_items)
@@ -254,7 +253,7 @@ module SupplejackApi
 
       it "ignores invalid set items but still saves the set" do
         user_set.update_attributes_and_embedded(records: [{"record_id" => "13", "position" => "1"}, {"record_id" => "shtig", "position" => "2"}])
-        # user_set.reload
+        user_set.reload
         expect(user_set.set_items.size).to eq 1
         expect(user_set.set_items.first.record_id).to eq 13
         expect(user_set.set_items.first.position).to eq 1
@@ -337,6 +336,20 @@ module SupplejackApi
 
       it "raises a error when then records array format is not correct" do
         expect { user_set.update_attributes_and_embedded(records: [1,2]) }.to raise_error(UserSet::WrongRecordsFormat)
+      end
+
+      it "overrides nil value for description" do
+        user_set.save
+        user_set.update_attributes_and_embedded(description: nil)
+        user_set.reload
+        expect(user_set.description).to eq ''
+      end
+
+      it "overrides nil value for description" do
+        user_set.save
+        user_set.update_attributes_and_embedded(approved: nil)
+        user_set.reload
+        expect(user_set.approved).to eq false
       end
     end
 


### PR DESCRIPTION
User sets created on dnz are being saved with nil values for :approved and :description. 

This branch will prevent that from happening. 