### PR TITLE
WIP: FIX HANDLING OF UnrecognizedFieldError

### DIFF
--- a/app/models/supplejack_api/concerns/searchable.rb
+++ b/app/models/supplejack_api/concerns/searchable.rb
@@ -261,6 +261,10 @@ module SupplejackApi::Concerns::Searchable
         end
       end
 
+
+      # This error comes from search_builder method.
+      # If i am to handle it there i will have to modify all the methods
+      # between solr_search_object and search builder. So handling it here
       begin
         solr_search_object
       rescue Sunspot::UnrecognizedFieldError => e

--- a/app/models/supplejack_api/concerns/searchable.rb
+++ b/app/models/supplejack_api/concerns/searchable.rb
@@ -250,6 +250,7 @@ module SupplejackApi::Concerns::Searchable
       offset.negative? ? 0 : offset
     end
 
+    # [FIXME] The error is reaised from here
     def valid?
       self.errors ||= []
       self.warnings ||= []

--- a/app/models/supplejack_api/concerns/searchable.rb
+++ b/app/models/supplejack_api/concerns/searchable.rb
@@ -261,7 +261,12 @@ module SupplejackApi::Concerns::Searchable
         end
       end
 
-      solr_search_object
+      begin
+        solr_search_object
+      rescue Sunspot::UnrecognizedFieldError => e
+        errors << e.message
+      end
+
       self.errors.empty?
     end
 

--- a/app/models/supplejack_api/concerns/searchable.rb
+++ b/app/models/supplejack_api/concerns/searchable.rb
@@ -250,7 +250,6 @@ module SupplejackApi::Concerns::Searchable
       offset.negative? ? 0 : offset
     end
 
-    # [FIXME] The error is reaised from here
     def valid?
       self.errors ||= []
       self.warnings ||= []
@@ -260,7 +259,6 @@ module SupplejackApi::Concerns::Searchable
           self.warnings << "The #{attribute} parameter can not exceed #{max_value}"
         end
       end
-
 
       # This error comes from search_builder method.
       # If i am to handle it there i will have to modify all the methods

--- a/spec/models/supplejack_api/search_spec.rb
+++ b/spec/models/supplejack_api/search_spec.rb
@@ -147,6 +147,53 @@ module SupplejackApi
       end
     end
 
+    describe '#valid?' do
+      before { @search.stub(:solr_search_object) { true } }
+
+      it 'returns true if no errors' do
+        @search.stub(:errors) { [] }
+        expect(@search.valid?).to be true
+      end
+
+      it 'returns false if errors exist' do
+        @search.stub(:errors) { ['some error'] }
+        expect(@search.valid?).to be false
+      end
+
+      it 'returns false when search bilder raises error' do
+        @search.stub(:solr_search_object).and_raise(Sunspot::UnrecognizedFieldError)
+        expect(@search.valid?).to be false
+      end
+
+      it 'sets warning if page vale is greater than 10000' do
+        @search.options[:page] = 100_001
+        @search.valid?
+
+        expect(@search.warnings).to include 'The page parameter can not exceed 100000'
+      end
+
+      it 'sets warning if per_page vale is greater than 100' do
+        @search.options[:per_page] = 101
+        @search.valid?
+
+        expect(@search.warnings).to include 'The per_page parameter can not exceed 100'
+      end
+
+      it 'sets warning if facets_per_page vale is greater than 350' do
+        @search.options[:facets_per_page] = 351
+        @search.valid?
+
+        expect(@search.warnings).to include 'The facets_per_page parameter can not exceed 350'
+      end
+
+      it 'sets warning if facets_page vale is greater than 5000' do
+        @search.options[:facets_page] = 5001
+        @search.valid?
+
+        expect(@search.warnings).to include 'The facets_page parameter can not exceed 5000'
+      end
+    end
+
     describe '#solr_search_object' do
       it 'memoizes the solr search object' do
         sunspot_mock = double(:solr).as_null_object

--- a/spec/models/supplejack_api/search_spec.rb
+++ b/spec/models/supplejack_api/search_spec.rb
@@ -148,20 +148,20 @@ module SupplejackApi
     end
 
     describe '#valid?' do
-      before { @search.stub(:solr_search_object) { true } }
+      before { allow(@search).to receive(:solr_search_object).and_return(true) }
 
       it 'returns true if no errors' do
-        @search.stub(:errors) { [] }
+        allow(@search).to receive(:errors).and_return([])
         expect(@search.valid?).to be true
       end
 
       it 'returns false if errors exist' do
-        @search.stub(:errors) { ['some error'] }
+        allow(@search).to receive(:errors).and_return(['some error'])
         expect(@search.valid?).to be false
       end
 
       it 'returns false when search bilder raises error' do
-        @search.stub(:solr_search_object).and_raise(Sunspot::UnrecognizedFieldError)
+        allow(@search).to receive(:solr_search_object).and_raise(Sunspot::UnrecognizedFieldError)
         expect(@search.valid?).to be false
       end
 


### PR DESCRIPTION
UnrecognizedFieldError is raised but not handled when unknown fields are passed for searching

*Acceptance Criteria*
- UnrecognizedFieldError API errors are handled in the API
- Airbrake stops complaining about them
- API returns a useful error message

Fix is now deployed in staging:
http://api.dnz0a.digitalnz.org/records.json?api_key=gV1woMjzQzsbzakmXXpb&&and%5Bprimary_collection%5D=National+Library+of+New+Zealand+Catalogue&text=123456&and%5B-dc_identifier%5D=ISBN*&per+page=100&fields=description