### PR TITLE
record content partner is now part of story request, sifter: 7578, pivotal :152543/stories/139998321

### DIFF
--- a/app/services/stories_api/v3/presenters/content/embed/dnz.rb
+++ b/app/services/stories_api/v3/presenters/content/embed/dnz.rb
@@ -11,7 +11,8 @@ module StoriesApi
               category: :category,
               image_url: :large_thumbnail_url,
               tags: :tag,
-              description: :description
+              description: :description,
+              content_partner: :content_partner
             }.freeze
 
             def call(block)

--- a/spec/dummy/app/supplejack_api/record_schema.rb
+++ b/spec/dummy/app/supplejack_api/record_schema.rb
@@ -24,7 +24,8 @@ class RecordSchema
   boolean   :nz_citizen,                          search_as: [:filter]
   string    :display_collection,                                search_as: [:filter, :fulltext],  namespace: :sj
   string    :tag,         multi_value: true,      search_as: [:filter]
-  string    :description,                 search_boost: 2,      search_as: [:filter, :fulltext],  namespace: :dc
+  string    :description,                         search_boost: 2,      search_as: [:filter, :fulltext],  namespace: :dc
+  string    :content_partner, multi_value: true,                                                          namespace: :dc
 
   # facets
   string    :category,     multi_value: true,     search_as: [:filter]

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -34,6 +34,7 @@ module SupplejackApi
 
     factory :record_fragment, class: SupplejackApi::ApiRecord::RecordFragment do
       title           'title'
+      content_partner  ['content partner']
       source_id       'source_name'
       priority        0
       name            'John Doe'

--- a/spec/services/stories_api/v3/presenters/content/embed/dnz_spec.rb
+++ b/spec/services/stories_api/v3/presenters/content/embed/dnz_spec.rb
@@ -25,7 +25,7 @@ module StoriesApi
             end
 
             it 'presents the record fields' do
-              [:title, :display_collection, :category, :image_url, :tags].each do |key|
+              [:title, :display_collection, :category, :image_url, :tags, :content_partner].each do |key|
                 expect(result).to have_key(key)
               end
             end


### PR DESCRIPTION
Why: story items on kereru need to show content partner  for legal
reasons
What: updated record schema, and presenter class