### PR TITLE
link saving of set item so that story.updated_at is also updated

### DIFF
--- a/app/models/supplejack_api/set_item.rb
+++ b/app/models/supplejack_api/set_item.rb
@@ -14,7 +14,8 @@ module SupplejackApi
 
     attr_accessor :record
 
-    embedded_in :user_set, class_name: 'SupplejackApi::UserSet'
+    #  touch: true ensures that the parent user_set updates its updated_at field when the set_item is edited and saved.
+    embedded_in :user_set, class_name: 'SupplejackApi::UserSet', touch: true
 
     field :record_id,   type: Integer
     field :position,    type: Integer

--- a/spec/models/supplejack_api/set_item_spec.rb
+++ b/spec/models/supplejack_api/set_item_spec.rb
@@ -58,6 +58,17 @@ module SupplejackApi
         expect(set_item).to receive(:set_position)
         set_item.save
       end
+
+       it "updates the user_set updated at field when an item is updated and saved" do
+        old_time = user_set.updated_at
+        set_item.position = 2
+        set_item.save!
+
+        expect(user_set.updated_at).to_not eq old_time
+      end
+
+
+
     end
 
     it "delegates record fields to the :record object" do


### PR DESCRIPTION
What: user sets will update their 'updated_at' attribute when a child…

Why: changes to stories items in kereru were not causing correct story ordering.