### PR TITLE
NEW DIGITALNZ SETS BROKEN ON KERERU(First item is broken)

### DIFF
--- a/app/controllers/supplejack_api/set_items_controller.rb
+++ b/app/controllers/supplejack_api/set_items_controller.rb
@@ -15,6 +15,7 @@ module SupplejackApi
     respond_to :json
 
     def create
+      # This ugly fix should be removed when digitalnz.org is decommissioned
       updated_params = record_params.merge(type: 'embed',
                                            sub_type: 'dnz',
                                            content: { record_id: record_params[:record_id] },

--- a/app/controllers/supplejack_api/set_items_controller.rb
+++ b/app/controllers/supplejack_api/set_items_controller.rb
@@ -21,7 +21,6 @@ module SupplejackApi
                                            content: { record_id: record_params[:record_id] },
                                            meta: { align_mode: 0 })
 
-
       @set_item = @user_set.set_items.build(updated_params)
       @user_set.save
       respond_with @user_set, @set_item

--- a/app/controllers/supplejack_api/set_items_controller.rb
+++ b/app/controllers/supplejack_api/set_items_controller.rb
@@ -17,9 +17,9 @@ module SupplejackApi
     def create
       updated_params = record_params.merge(type: 'embed',
                                            sub_type: 'dnz',
-                                           content: { record_id: record_params[:record_id] })
+                                           content: { record_id: record_params[:record_id] },
+                                           meta: { align_mode: 0 })
 
-      Rails.logger.info "STORIES: #{updated_params}"
 
       @set_item = @user_set.set_items.build(updated_params)
       @user_set.save

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -128,7 +128,6 @@ module SupplejackApi::Concerns::UserSet
           begin
             new_set_items = []
             set_items.each do |set_item_hash|
-
               # This ugly fix should be removed when digitalnz.org is decommissioned
               params = { record_id: set_item_hash['record_id'], type: 'embed',
                          sub_type: 'dnz', content: { record_id: set_item_hash['record_id'] },

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -128,7 +128,11 @@ module SupplejackApi::Concerns::UserSet
           begin
             new_set_items = []
             set_items.each do |set_item_hash|
-              set_item = self.set_items.find_or_initialize_by(record_id: set_item_hash['record_id'])
+              params = { record_id: set_item_hash['record_id'], type: 'embed',
+                         sub_type: 'dnz', content: { record_id: set_item_hash['record_id'] },
+                         meta: { align_mode: 0 } }
+
+              set_item = self.set_items.find_or_initialize_by(params)
               set_item.position = set_item_hash['position']
 
               new_set_items << set_item

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -128,6 +128,8 @@ module SupplejackApi::Concerns::UserSet
           begin
             new_set_items = []
             set_items.each do |set_item_hash|
+
+              # This ugly fix should be removed when digitalnz.org is decommissioned
               params = { record_id: set_item_hash['record_id'], type: 'embed',
                          sub_type: 'dnz', content: { record_id: set_item_hash['record_id'] },
                          meta: { align_mode: 0 } }

--- a/spec/controllers/supplejack_api/set_items_controller_spec.rb
+++ b/spec/controllers/supplejack_api/set_items_controller_spec.rb
@@ -24,7 +24,7 @@ module SupplejackApi
     describe "POST 'create'" do
       it 'creates the set item through the @user_set' do
         create(:record_with_fragment, record_id: 12345)
-        expect(@user_set.set_items).to receive(:build).with({"record_id"=>"12345", "type"=>"embed", "sub_type"=>"dnz", "content"=>{"record_id"=>"12345"}}) { @set_item }
+        expect(@user_set.set_items).to receive(:build).with({"record_id"=>"12345", "type"=>"embed", "sub_type"=>"dnz", "content"=>{"record_id"=>"12345"}, "meta"=>{"align_mode"=>0}}) { @set_item }
         expect(@user_set).to receive(:save).and_return(true)
         post :create, user_set_id: @user_set.id, record: { record_id: '12345' }, format: :json
       end

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -313,14 +313,14 @@ module SupplejackApi
 
       it "initializes the set_items through the user_set" do
         item = user_set.set_items.build(record_id: 13)
-        expect(user_set.set_items).to receive(:find_or_initialize_by).with({record_id: "13"}) { item }
+        expect(user_set.set_items).to receive(:find_or_initialize_by).with({record_id: "13", :type=>"embed", :sub_type=>"dnz", :content=>{:record_id=>"13"}, :meta=>{:align_mode=>0}}) { item }
         user_set.update_attributes_and_embedded(records: [{"record_id" => "13", "position" => nil}])
       end
 
       it "can replace the set items" do
         user_set.save
-        user_set.set_items.create(record_id: 13)
-        user_set.update_attributes_and_embedded(records: [{"record_id" => "13", "position" => nil}])
+        user_set.set_items.create(record_id: 13, :type=>"embed", :sub_type=>"dnz", :content=>{:record_id=>"13"}, :meta=>{:align_mode=>0})
+        user_set.update_attributes_and_embedded(records: [{"record_id" => "13", "position" => nil, :type=>"embed", :sub_type=>"dnz", :content=>{:record_id=>"13"}, :meta=>{:align_mode=>0}}])
         user_set.reload
         expect(user_set.set_items.size).to eq 1
         expect(user_set.set_items.first.record_id).to eq 13


### PR DESCRIPTION
- When creating a new set from DigitalNZ with an item, the item dosent have type and sub_type.
- I have written a temporary fix till digitalnz is decommissioned.