### PR TITLE
add story_item_id to record_ids field for API response

### DIFF
--- a/app/services/stories_api/v3/presenters/story.rb
+++ b/app/services/stories_api/v3/presenters/story.rb
@@ -33,7 +33,9 @@ module StoriesApi
           result[:number_of_items] = story.set_items.count
 
           if slim
-            result[:record_ids] = story.set_items.sort_by(&:position).map { |x| { record_id: x.record_id, story_item_id: x._id.to_s } }
+            result[:record_ids] = story.set_items.sort_by(&:position).map do |item|
+              { record_id: item.record_id, story_item_id: item._id.to_s }
+            end
           else
             result[:contents] = story.set_items.sort_by(&:position).map do |item|
               StoriesApi::V3::Presenters::StoryItem.new.call(item, story)

--- a/app/services/stories_api/v3/presenters/story.rb
+++ b/app/services/stories_api/v3/presenters/story.rb
@@ -33,7 +33,7 @@ module StoriesApi
           result[:number_of_items] = story.set_items.count
 
           if slim
-            result[:record_ids] = story.set_items.sort_by(&:position).map { |x| { record_id: x.record_id } }
+            result[:record_ids] = story.set_items.sort_by(&:position).map { |x| { record_id: x.record_id, story_item_id: x._id.to_s } }
           else
             result[:contents] = story.set_items.sort_by(&:position).map do |item|
               StoriesApi::V3::Presenters::StoryItem.new.call(item, story)

--- a/spec/services/stories_api/v3/presenters/story_spec.rb
+++ b/spec/services/stories_api/v3/presenters/story_spec.rb
@@ -10,34 +10,66 @@ module StoriesApi
 
           story
         end
-        let(:presented_json) {subject.call(story)}
 
-        it 'presents all top level fields' do
-          [:name, :description, :privacy, :copyright, :featured, :approved, :tags].each do |field|
-            expect(presented_json[field]).to eq(story.send(field))
+        context "called without any parameter or with slim equals false" do
+          let(:presented_json) {subject.call(story)}
+
+          it 'presents all top level fields' do
+            [:name, :description, :privacy, :copyright, :featured, :approved, :tags].each do |field|
+              expect(presented_json[field]).to eq(story.send(field))
+            end
+          end
+
+          it 'presents the id field as a string' do
+            expect(presented_json[:id]).to eq(story.id.to_s)
+          end
+
+          it 'presents number_of_items as the count of the items in the UserSet' do
+            expect(presented_json[:number_of_items]).to eq(story.set_items.count)
+          end
+
+          it 'presents the contents field as an array of valid StoryItems' do
+            expect(
+              presented_json[:contents].all? do |story_item|
+                ::StoriesApi::V3::Schemas::StoryItem::BlockValidator.new.call(story_item)
+              end
+            ).to eq(true)
+          end
+
+          it 'presents the contents sorted by their position' do
+            positions = presented_json[:contents].map{|content| content[:position]}
+
+            expect(positions).to eq(positions.sort)
           end
         end
 
-        it 'presents the id field as a string' do
-          expect(presented_json[:id]).to eq(story.id.to_s)
-        end
+        context "with slim paramter equals true" do
+          let(:presented_json) {subject.call(story, slim = true)}
 
-        it 'presents number_of_items as the count of the items in the UserSet' do
-          expect(presented_json[:number_of_items]).to eq(story.set_items.count)
-        end
-
-        it 'presents the contents field as an array of valid StoryItems' do
-          expect(
-            presented_json[:contents].all? do |story_item|
-              ::StoriesApi::V3::Schemas::StoryItem::BlockValidator.new.call(story_item)
+          it 'presents all top level fields' do
+            [:name, :description, :privacy, :copyright, :featured, :approved, :tags].each do |field|
+              expect(presented_json[field]).to eq(story.send(field))
             end
-          ).to eq(true)
-        end
+          end
 
-        it 'presents the contents sorted by their position' do
-          positions = presented_json[:contents].map{|content| content[:position]}
+          it 'presents the id field as a string' do
+            expect(presented_json[:id]).to eq(story.id.to_s)
+          end
 
-          expect(positions).to eq(positions.sort)
+          it 'presents number_of_items as the count of the items in the UserSet' do
+            expect(presented_json[:number_of_items]).to eq(story.set_items.count)
+          end
+
+          it 'presents the contents field as nil' do
+            expect(presented_json[:contents]).to be_nil
+          end
+
+          it 'presents the record_ids sorted by their position' do
+            record_id_sorted = story.set_items.sort_by(&:position).map{ |x| x.record_id }
+            story_item_id_sorted = story.set_items.sort_by(&:position).map{ |x| x._id.to_s }
+            expect(presented_json[:record_ids].map{|item| item[:record_id] }).to eq(record_id_sorted)
+            expect(presented_json[:record_ids].map{|item| item[:story_item_id] }).to eq(story_item_id_sorted)
+          end
         end
       end
     end


### PR DESCRIPTION
To allow the story_item can be added and removed in the Search results page. 
(Due to the change to Slim parameter of API, we only return the record_id of stories when slim=true.)