### PR TITLE
Use small thumbnail on story item, if no large one exists

### DIFF
--- a/app/services/stories_api/v3/presenters/content/embed/dnz.rb
+++ b/app/services/stories_api/v3/presenters/content/embed/dnz.rb
@@ -27,6 +27,8 @@ module StoriesApi
                 result[name] = record.public_send(field)
               end
 
+              result[:image_url] = record.thumbnail_url if result[:image_url].nil?
+
               result
             end
           end

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -30,6 +30,18 @@ module SupplejackApi
                              tag: tag)]
         end
       end
+
+      factory :record_with_no_large_thumb do
+        fragments do
+          [FactoryGirl.build(:record_fragment,
+                             display_collection: display_collection,
+                             copyright: copyright,
+                             category: category,
+                             tag: tag,
+                             large_thumbnail_url: nil)]
+        end
+      end
+
     end
 
     factory :record_fragment, class: SupplejackApi::ApiRecord::RecordFragment do
@@ -47,6 +59,7 @@ module SupplejackApi
       nz_citizen      true
       display_collection 'test'
       large_thumbnail_url    'http://my-website-that-hosts-images/image.png'
+      thumbnail_url    'http://my-website-that-hosts-images/small-image.png'
     end
   end
 end

--- a/spec/services/stories_api/v3/presenters/content/embed/dnz_spec.rb
+++ b/spec/services/stories_api/v3/presenters/content/embed/dnz_spec.rb
@@ -33,6 +33,17 @@ module StoriesApi
             it 'presents them from the correct record' do
               expect(result[:title]).to eq(record.title)
             end
+
+            context 'no large_thumbnail_url' do
+              let(:record) {create(:record_with_no_large_thumb)}
+              let(:block) {create(:embed_dnz_item, id: record.record_id)}
+              let(:result) {subject.call(block)}
+
+              it 'presents thumbnail_url if there is no large_thumbnail_url' do
+
+                expect(result[:image_url]).to eq record.thumbnail_url
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
_Acceptance Criteria_
- Stories API checks both thumbnail_url and large_thumbnail_url for 'image_url'
https://boost.sifterapp.com/issues/7648

*Notes*
- See the "Hotdog" and "Seascape" items not showing images in this set. But clicking through to each item will show images available.
http://beta.dnz0a.digitalnz.org/stories/58a37851297b1f48e100000d/show
