### PR TITLE
ADD NEW SUBJECTS FIELD TO SETS/STORIES & SYNC IT WITH TAGS

### DIFF
--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -178,6 +178,8 @@ module SupplejackApi::Concerns::UserSet
 
       # The code below writes any updates in tags to subjects
       self.subjects = tags
+
+      # The code below is commented out as we dont know if we have to sync tags to subjects yet
       # stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
       # self.subjects = (tags + (stripped_subjects || [])).uniq
 

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -33,6 +33,7 @@ module SupplejackApi::Concerns::UserSet
     field :count,               type: Integer,  default: 0
     field :count_updated_at,    type: DateTime
     field :tags,                type: Array,    default: []
+    field :subjects,            type: Array,    default: []
     field :approved,            type: Boolean,  default: false
     field :featured,            type: Boolean,  default: false
     field :featured_at,         type: DateTime
@@ -172,7 +173,14 @@ module SupplejackApi::Concerns::UserSet
         send("#{attr}=", strip_tags(self[attr])) if self[attr].present?
       end
 
-      self.tags = self[:tags].map { |t| strip_tags(t) } if tags.try(:any?)
+      # This is the original code
+      # self.tags = self[:tags].map { |t| strip_tags(t) } if tags.try(:any?)
+
+      # The code below is a temporary solution to keep tags and subjects synced
+      stripped_tags = self[:tags].map { |tag| strip_tags(tag) } if tags.try(:any?)
+      stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
+
+      self.tags = self.subjects = ((stripped_tags || []) + (stripped_subjects || [])).uniq       
     end
 
     def update_record

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -179,7 +179,7 @@ module SupplejackApi::Concerns::UserSet
       # The code below writes any updates in tags to subjects
       self.subjects = tags
 
-      # The code below is commented out as we dont know if we have to sync tags to subjects yet
+      # The code below is commented out as we dont know if we have to sync tags to subjects and back yet
       # stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
       # self.subjects = (tags + (stripped_subjects || [])).uniq
 

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -177,8 +177,9 @@ module SupplejackApi::Concerns::UserSet
       self.tags = self[:tags].map { |t| strip_tags(t) } if tags.try(:any?)
 
       # The code below writes any updates in tags to subjects
-      stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
-      self.subjects = (tags + (stripped_subjects || [])).uniq
+      self.subjects = tags
+      # stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
+      # self.subjects = (tags + (stripped_subjects || [])).uniq
 
       # The code below is a temporary solution to keep tags and subjects synced
       # stripped_tags = self[:tags].map { |tag| strip_tags(tag) } if tags.try(:any?)

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -174,13 +174,17 @@ module SupplejackApi::Concerns::UserSet
       end
 
       # This is the original code
-      # self.tags = self[:tags].map { |t| strip_tags(t) } if tags.try(:any?)
+      self.tags = self[:tags].map { |t| strip_tags(t) } if tags.try(:any?)
+
+      # The code below writes any updates in tags to subjects
+      stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
+      self.subjects = (tags + (stripped_subjects || [])).uniq
 
       # The code below is a temporary solution to keep tags and subjects synced
-      stripped_tags = self[:tags].map { |tag| strip_tags(tag) } if tags.try(:any?)
-      stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
+      # stripped_tags = self[:tags].map { |tag| strip_tags(tag) } if tags.try(:any?)
+      # stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
 
-      self.tags = self.subjects = ((stripped_tags || []) + (stripped_subjects || [])).uniq       
+      # self.tags = self.subjects = ((stripped_tags || []) + (stripped_subjects || [])).uniq
     end
 
     def update_record

--- a/app/services/stories_api/v3/presenters/story.rb
+++ b/app/services/stories_api/v3/presenters/story.rb
@@ -18,6 +18,7 @@ module StoriesApi
           :featured,
           :approved,
           :tags,
+          :subjects,
           :updated_at,
           :cover_thumbnail
         ].freeze

--- a/spec/services/stories_api/v3/endpoints/story_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_spec.rb
@@ -159,7 +159,7 @@ module StoriesApi
               updated_story = SupplejackApi::UserSet.custom_find(story.id)
 
               expect(updated_story.description).to eq(patch[:description])
-              expect(updated_story.tags).to eq(patch[:tags] + patch[:subjects])
+              expect(updated_story.tags).to eq(patch[:tags])
               expect(updated_story.subjects).to eq(patch[:tags] + patch[:subjects])
             end
           end

--- a/spec/services/stories_api/v3/endpoints/story_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_spec.rb
@@ -160,7 +160,7 @@ module StoriesApi
 
               expect(updated_story.description).to eq(patch[:description])
               expect(updated_story.tags).to eq(patch[:tags])
-              expect(updated_story.subjects).to eq(patch[:tags] + patch[:subjects])
+              expect(updated_story.subjects).to eq(patch[:tags])# + patch[:subjects])
             end
           end
         end

--- a/spec/services/stories_api/v3/endpoints/story_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_spec.rb
@@ -113,8 +113,7 @@ module StoriesApi
           let(:patch) do
             {
               description: 'foobar',
-              tags: ['tags', 'go', 'here'],
-              subjects: ['tango', 'charlie']
+              tags: ['tags', 'go', 'here']
             }
           end
 
@@ -160,7 +159,7 @@ module StoriesApi
 
               expect(updated_story.description).to eq(patch[:description])
               expect(updated_story.tags).to eq(patch[:tags])
-              expect(updated_story.subjects).to eq(patch[:tags])# + patch[:subjects])
+              expect(updated_story.subjects).to eq(patch[:tags])
             end
           end
         end

--- a/spec/services/stories_api/v3/endpoints/story_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_spec.rb
@@ -113,7 +113,8 @@ module StoriesApi
           let(:patch) do
             {
               description: 'foobar',
-              tags: ['tags', 'go', 'here']
+              tags: ['tags', 'go', 'here'],
+              subjects: ['tango', 'charlie']
             }
           end
 
@@ -158,7 +159,8 @@ module StoriesApi
               updated_story = SupplejackApi::UserSet.custom_find(story.id)
 
               expect(updated_story.description).to eq(patch[:description])
-              expect(updated_story.tags).to eq(patch[:tags])
+              expect(updated_story.tags).to eq(patch[:tags] + patch[:subjects])
+              expect(updated_story.subjects).to eq(patch[:tags] + patch[:subjects])
             end
           end
         end


### PR DESCRIPTION
- Added a new field subjects to user_sets
- Updated before filer method that initialises tags before save to copy tags to subjects (This is a temporary solution till tags are completely replaced by subjects)
- Added subjects to stories presenter