### PR TITLE
UPDATE KERERU AND DNZ TO USE SUBJECTS

### DIFF
--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -231,11 +231,11 @@ module SupplejackApi::Concerns::UserSet
 
     def tag_list=(tags_string)
       tags_string = tags_string.to_s.gsub(/[^A-Za-z0-9\p{Word} ,_-]/, '')
-      self.tags = tags_string.to_s.split(',').map(&:strip).reject(&:blank?)
+      self.subjects = tags_string.to_s.split(',').map(&:strip).reject(&:blank?)
     end
 
     def tag_list
-      tags.join(', ') if tags.present?
+      subjects.join(', ') if subjects.present?
     end
 
     # Return a array of SetItem objects with the actual Record object attached through

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -173,21 +173,11 @@ module SupplejackApi::Concerns::UserSet
         send("#{attr}=", strip_tags(self[attr])) if self[attr].present?
       end
 
-      # This is the original code
-      self.tags = self[:tags].map { |t| strip_tags(t) } if tags.try(:any?)
+      self.subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
+      self.tags = subjects
 
-      # The code below writes any updates in tags to subjects
-      self.subjects = tags
-
-      # The code below is commented out as we dont know if we have to sync tags to subjects and back yet
-      # stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
-      # self.subjects = (tags + (stripped_subjects || [])).uniq
-
-      # The code below is a temporary solution to keep tags and subjects synced
-      # stripped_tags = self[:tags].map { |tag| strip_tags(tag) } if tags.try(:any?)
-      # stripped_subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
-
-      # self.tags = self.subjects = ((stripped_tags || []) + (stripped_subjects || [])).uniq
+      # Uncomment this when tags to subject syncing is removed
+      # self.tags = self[:tags].map { |tag| strip_tags(tag) } if tags.try(:any?)
     end
 
     def update_record

--- a/app/serializers/supplejack_api/user_set_serializer.rb
+++ b/app/serializers/supplejack_api/user_set_serializer.rb
@@ -8,7 +8,7 @@
 
 module SupplejackApi
   class UserSetSerializer < ActiveModel::Serializer
-    attributes :name, :count, :priority, :featured, :approved, :created_at, :updated_at, :tags, :privacy
+    attributes :name, :count, :priority, :featured, :approved, :created_at, :updated_at, :tags, :privacy, :subjects
     has_one :record, serializer: UserSetRecordSerializer
     root :set
 
@@ -24,6 +24,7 @@ module SupplejackApi
         hash[:description] = object.description
         hash[:privacy] = object.privacy
         hash[:tags] = object.tags
+        hash[:subjects] = object.subjects
         hash[:records] = records
       elsif options[:featured]
         hash[:records] = records(1)

--- a/app/services/stories_api/v3/endpoints/stories.rb
+++ b/app/services/stories_api/v3/endpoints/stories.rb
@@ -34,6 +34,8 @@ module StoriesApi
         end
 
         def post
+          return create_error('UserNotFound', id: params[:user_key]) unless user.present?
+
           story = params[:story]
 
           return create_error('MandatoryParamMissing', param: :name) unless story.is_a?(Hash) && story[:name].present?

--- a/app/services/stories_api/v3/schemas/story.rb
+++ b/app/services/stories_api/v3/schemas/story.rb
@@ -38,6 +38,7 @@ module StoriesApi
         required(:number_of_items).filled(:int?, gteq?: 0)
         required(:contents).each(:valid_block?)
         optional(:cover_thumbnail)
+        optional(:subjects).each(:str?)
       end
     end
   end

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -64,11 +64,18 @@ module SupplejackApi
           expect(user_set.description).to eq "Dogs and Cats"
         end
 
-        it "removes html tags from the tags" do
-          user_set.tags = ["Dogs", "<b>Cats</b>"]
+        it "removes html tags from the subjects" do
+          user_set.subjects = ["Dogs", "<b>Cats</b>"]
           user_set.strip_html_tags
-          expect(user_set.tags).to eq ["Dogs", "Cats"]
+          expect(user_set.subjects).to eq ["Dogs", "Cats"]
         end
+
+        # Suspended till subject to tag syn is removed
+        # it "removes html tags from the tags" do
+        #   user_set.tags = ["Dogs", "<b>Cats</b>"]
+        #   user_set.strip_html_tags
+        #   expect(user_set.tags).to eq ["Dogs", "Cats"]
+        # end
       end
 
       it "calls update_record before saving" do

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -503,12 +503,12 @@ module SupplejackApi
     describe "#tag_list=" do
       it "should convert the comma seperate string to an array of tags" do
         user_set.tag_list = "dogs, animals, cats"
-        expect(user_set.tags).to include("dogs", "cats", "animals")
+        expect(user_set.subjects).to include("dogs", "cats", "animals")
       end
 
       it "removes empty tags" do
         user_set.tag_list = "dogs, , animals"
-        expect(user_set.tags.size).to eq(2)
+        expect(user_set.subjects.size).to eq(2)
       end
 
       it "handles a nil tag list" do
@@ -518,13 +518,13 @@ module SupplejackApi
 
       it "strips tags from punctuations except - and _" do
         user_set.tag_list = "hola! d-a_s_h @#$\%^&*()+=.;: ,something else"
-        expect(user_set.tags).to eq ["hola d-a_s_h", "something else"]
+        expect(user_set.subjects).to eq ["hola d-a_s_h", "something else"]
       end
     end
 
     describe "#tag_list" do
       it "returns a comma seperated list of tags" do
-        user_set.tags = ["animal","dog","beast"]
+        user_set.subjects = ["animal","dog","beast"]
         expect(user_set.tag_list).to eq("animal, dog, beast")
       end
 

--- a/spec/services/perform_merge_patch_spec.rb
+++ b/spec/services/perform_merge_patch_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe PerformMergePatch do
   context 'validating the updated model against the schema' do
     let(:patch) { super().update(description: 123) }
 
-    it 'does not modify the model if the Schema validation fails' do
-      expect(story.tags).to eq(['story', 'tags'])
-    end
+    # Suspended till subject to tag syn is removed
+    # it 'does not modify the model if the Schema validation fails' do
+    #   expect(story.tags).to eq(['story', 'tags'])
+    # end
 
     it 'returns false if validation fails' do
       expect(merge_result).to eq(false)

--- a/spec/services/stories_api/v3/endpoints/stories_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/stories_spec.rb
@@ -48,8 +48,9 @@ module StoriesApi
         end
 
         describe '#post' do
+          let(:user) { create(:user) }
           it 'returns 400 if the name field is missing for the Story' do
-            response = Stories.new(story: '111').post
+            response = Stories.new(story: '111', user_key: user.api_key).post
 
             expect(response).to eq(
               status: 400,
@@ -60,7 +61,6 @@ module StoriesApi
           end
 
           context 'succesful request' do
-            let(:user) { create(:user) }
             let!(:response) { Stories.new(story: { name: 'Story Name' }, user_key: user.api_key).post }
 
             before do

--- a/spec/services/stories_api/v3/endpoints/story_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_spec.rb
@@ -113,7 +113,7 @@ module StoriesApi
           let(:patch) do
             {
               description: 'foobar',
-              tags: ['tags', 'go', 'here']
+              subjects: ['tags', 'go', 'here']
             }
           end
 
@@ -158,8 +158,7 @@ module StoriesApi
               updated_story = SupplejackApi::UserSet.custom_find(story.id)
 
               expect(updated_story.description).to eq(patch[:description])
-              expect(updated_story.tags).to eq(patch[:tags])
-              expect(updated_story.subjects).to eq(patch[:tags])
+              expect(updated_story.subjects).to eq(patch[:subjects])
             end
           end
         end


### PR DESCRIPTION
Why  : Tags needs to be synced to subjects temporarily
What : - Added html tag stripping for subjects
            - Syncing tags to subjects
            - Added UserNotFound exception to stories post service
            - Commented spec and code that needs to be uncommented after syncing is removed