### PR TITLE
added story author to story presenter

### DIFF
--- a/app/services/stories_api/v3/presenters/story.rb
+++ b/app/services/stories_api/v3/presenters/story.rb
@@ -32,6 +32,7 @@ module StoriesApi
 
           result[:id] = story.id.to_s
           result[:number_of_items] = story.set_items.count
+          result[:creator] = story.user.name
 
           if slim
             result[:record_ids] = story.set_items.sort_by(&:position).map do |item|

--- a/spec/services/stories_api/v3/presenters/story_spec.rb
+++ b/spec/services/stories_api/v3/presenters/story_spec.rb
@@ -24,6 +24,10 @@ module StoriesApi
             expect(presented_json[:id]).to eq(story.id.to_s)
           end
 
+          it 'presents the story creator' do
+            expect(presented_json[:creator]).to eq(story.user.name)
+          end
+
           it 'presents number_of_items as the count of the items in the UserSet' do
             expect(presented_json[:number_of_items]).to eq(story.set_items.count)
           end


### PR DESCRIPTION
WHY: 'Remove edit mode' on kereru has acceptance crieteria: story author is shown on page.