### PR TITLE
WHAT: story / set subjects defaults to empty array, instead of nil

### DIFF
--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -173,7 +173,8 @@ module SupplejackApi::Concerns::UserSet
         send("#{attr}=", strip_tags(self[attr])) if self[attr].present?
       end
 
-      self.subjects = self[:subjects].map { |subject| strip_tags(subject) } if subjects.try(:any?)
+      self[:subjects] = [] unless self[:subjects]
+      self.subjects = self[:subjects].map { |subject| strip_tags(subject) }
       self.tags = subjects
 
       # Uncomment this when tags to subject syncing is removed


### PR DESCRIPTION
WHY: this was causing a bug