### PR TITLE
UNLINK SUBJECTS AND TAGS IN API

### DIFF
--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -175,10 +175,9 @@ module SupplejackApi::Concerns::UserSet
 
       self[:subjects] = [] unless self[:subjects]
       self.subjects = self[:subjects].map { |subject| strip_tags(subject) }
-      self.tags = subjects
 
-      # Uncomment this when tags to subject syncing is removed
-      # self.tags = self[:tags].map { |tag| strip_tags(tag) } if tags.try(:any?)
+      self[:tags] = [] unless self[:tags]
+      self.tags = self[:tags].map { |tag| strip_tags(tag) } # if tags.try(:any?)
     end
 
     def update_record

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -58,7 +58,7 @@ module SupplejackApi::Concerns::UserSet
 
     before_validation :set_default_privacy
     before_save :calculate_count
-    before_save :strip_html_tags
+    before_save :strip_html_tags!
     before_save :update_record
     after_save :reindex_items
     before_destroy :delete_record
@@ -168,7 +168,7 @@ module SupplejackApi::Concerns::UserSet
 
     # Remove HTML tags from the name, description and tags
     #
-    def strip_html_tags
+    def strip_html_tags!
       [:name, :description].each do |attr|
         send("#{attr}=", strip_tags(self[attr])) if self[attr].present?
       end

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -61,25 +61,25 @@ module SupplejackApi
         end
         it "removes html tags from the name" do
           user_set.name = "Dogs and <b>Cats</b>"
-          user_set.strip_html_tags
+          user_set.strip_html_tags!
           expect(user_set.name).to eq "Dogs and Cats"
         end
 
         it "removes html tags from the description" do
           user_set.description = "Dogs and <b>Cats</b>"
-          user_set.strip_html_tags
+          user_set.strip_html_tags!
           expect(user_set.description).to eq "Dogs and Cats"
         end
 
         it "removes html tags from the subjects" do
           user_set.subjects = ["Dogs", "<b>Cats</b>"]
-          user_set.strip_html_tags
+          user_set.strip_html_tags!
           expect(user_set.subjects).to eq ["Dogs", "Cats"]
         end
 
         it "removes html tags from the tags" do
           user_set.tags = ["Dogs", "<b>Cats</b>"]
-          user_set.strip_html_tags
+          user_set.strip_html_tags!
           expect(user_set.tags).to eq ["Dogs", "Cats"]
         end
       end

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -77,12 +77,11 @@ module SupplejackApi
           expect(user_set.subjects).to eq ["Dogs", "Cats"]
         end
 
-        # Suspended till subject to tag syn is removed
-        # it "removes html tags from the tags" do
-        #   user_set.tags = ["Dogs", "<b>Cats</b>"]
-        #   user_set.strip_html_tags
-        #   expect(user_set.tags).to eq ["Dogs", "Cats"]
-        # end
+        it "removes html tags from the tags" do
+          user_set.tags = ["Dogs", "<b>Cats</b>"]
+          user_set.strip_html_tags
+          expect(user_set.tags).to eq ["Dogs", "Cats"]
+        end
       end
 
       it "calls update_record before saving" do

--- a/spec/services/perform_merge_patch_spec.rb
+++ b/spec/services/perform_merge_patch_spec.rb
@@ -19,10 +19,9 @@ RSpec.describe PerformMergePatch do
   context 'validating the updated model against the schema' do
     let(:patch) { super().update(description: 123) }
 
-    # Suspended till subject to tag syn is removed
-    # it 'does not modify the model if the Schema validation fails' do
-    #   expect(story.tags).to eq(['story', 'tags'])
-    # end
+    it 'does not modify the model if the Schema validation fails' do
+      expect(story.tags).to eq(['story', 'tags'])
+    end
 
     it 'returns false if validation fails' do
       expect(merge_result).to eq(false)

--- a/spec/services/stories_api/v3/endpoints/story_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_spec.rb
@@ -113,7 +113,8 @@ module StoriesApi
           let(:patch) do
             {
               description: 'foobar',
-              subjects: ['tags', 'go', 'here']
+              tags: ['tags', 'go', 'here'],
+              subjects: ['subjects', 'go', 'here']
             }
           end
 
@@ -159,6 +160,7 @@ module StoriesApi
 
               expect(updated_story.description).to eq(patch[:description])
               expect(updated_story.subjects).to eq(patch[:subjects])
+              expect(updated_story.tags).to eq(patch[:tags])
             end
           end
         end


### PR DESCRIPTION
- `tags` were being synced from `subjects` in user sets. This was a temporary solution.
- This is to be reverted.
- Enable suspended specs.
- Update specs for tags and subjects