### PR TITLE
MODERATE KERERU STORIES

### DIFF
--- a/app/controllers/supplejack_api/stories/moderations_controller.rb
+++ b/app/controllers/supplejack_api/stories/moderations_controller.rb
@@ -13,7 +13,7 @@ module SupplejackApi
       respond_to :json
       before_action :authenticate_admin!
 
-      def index
+      def show
         @user_sets = UserSet.public_sets(page: params[:page])
         render json: serializable_array(@user_sets, user: true, total: true).to_json
       end

--- a/app/controllers/supplejack_api/stories/moderations_controller.rb
+++ b/app/controllers/supplejack_api/stories/moderations_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true# frozen_string_literal: true
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
+# the Department of Internal Affairs. http://digitalnz.org/supplejack
+
+module SupplejackApi
+  module Stories
+    class ModerationsController < ApplicationController
+
+      respond_to :json
+      before_action :authenticate_admin!
+
+      def index
+        @user_sets = UserSet.public_sets(page: params[:page])
+        render json: serializable_array(@user_sets, user: true, total: true).to_json
+      end
+
+      private
+
+      def serializable_array(user_sets, options = {})
+        options.reverse_merge!(root: false, items: false, user: false, total: false)
+        hash = { 'sets' => [] }
+        user_sets.each do |set|
+          hash['sets'] << UserSetSerializer.new(set, options).as_json
+        end
+        hash['total'] = UserSet.public_sets_count if options[:total]
+        hash
+      end
+    end
+  end
+end

--- a/app/controllers/supplejack_api/stories/moderations_controller.rb
+++ b/app/controllers/supplejack_api/stories/moderations_controller.rb
@@ -9,7 +9,6 @@
 module SupplejackApi
   module Stories
     class ModerationsController < ApplicationController
-
       respond_to :json
       before_action :authenticate_admin!
 

--- a/app/controllers/supplejack_api/stories/moderations_controller.rb
+++ b/app/controllers/supplejack_api/stories/moderations_controller.rb
@@ -24,7 +24,7 @@ module SupplejackApi
         options.reverse_merge!(root: false, items: false, user: false, total: false)
         hash = { 'sets' => [] }
         user_sets.each do |set|
-          hash['sets'] << UserSetSerializer.new(set, options).as_json
+          hash['sets'] << StoriesModerationSerializer.new(set, options).as_json
         end
         hash['total'] = UserSet.public_sets_count if options[:total]
         hash

--- a/app/serializers/supplejack_api/stories_moderation_serializer.rb
+++ b/app/serializers/supplejack_api/stories_moderation_serializer.rb
@@ -11,4 +11,3 @@ module SupplejackApi
     attributes :id, :name, :user, :count, :approved, :created_at, :updated_at
   end
 end
-

--- a/app/serializers/supplejack_api/stories_moderation_serializer.rb
+++ b/app/serializers/supplejack_api/stories_moderation_serializer.rb
@@ -8,7 +8,7 @@
 
 module SupplejackApi
   class StoriesModerationSerializer < ActiveModel::Serializer
-    attributes :id, :name, :count, :approved, :created_at, :updated_at
+    attributes :id, :name, :user, :count, :approved, :created_at, :updated_at
   end
 end
 

--- a/app/serializers/supplejack_api/stories_moderation_serializer.rb
+++ b/app/serializers/supplejack_api/stories_moderation_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
+# the Department of Internal Affairs. http://digitalnz.org/supplejack
+
+module SupplejackApi
+  class StoriesModerationSerializer < ActiveModel::Serializer
+    attributes :id, :name, :count, :approved, :created_at, :updated_at
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
-# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government, 
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
 # and is licensed under the GNU General Public License, version 3.
-# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and 
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 
 require 'sidekiq/web'
@@ -12,6 +12,10 @@ SupplejackApi::Engine.routes.draw do
   root to: 'records#index'
 
   devise_for :users, class_name: 'SupplejackApi::User'
+
+  namespace :stories do
+    resources :moderations, only: [:index]
+  end
 
   # Admin level authentication
   namespace :admin do
@@ -31,7 +35,7 @@ SupplejackApi::Engine.routes.draw do
     resources :concepts, only: [:index, :show] do
       resources :records, only: [:index], on: :member
     end
-    
+
     # Records
     resources :records, only: [:index, :show] do
       get :multiple, on: :collection
@@ -80,6 +84,7 @@ SupplejackApi::Engine.routes.draw do
       get :link_check_records, on: :member
     end
   end
+
 
   # Sources
   resources :sources, only: [:index, :update], constraints: SupplejackApi::HarvesterConstraint.new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ SupplejackApi::Engine.routes.draw do
   devise_for :users, class_name: 'SupplejackApi::User'
 
   namespace :stories do
-    resources :moderations, only: [:index]
+    resource :moderation, only: [:show]
   end
 
   # Admin level authentication

--- a/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
@@ -47,6 +47,8 @@ module SupplejackApi
               expect(set).to have_key 'created_at'
               expect(set).to have_key 'updated_at'
             end
+
+            expect(sets).to have_key 'total'
           end
         end
       end

--- a/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
@@ -13,41 +13,51 @@ module SupplejackApi
     describe ModerationsController do
       routes { SupplejackApi::Engine.routes }
 
-      before(:each) do
-        @user = FactoryGirl.create(:user, authentication_token: "abc123")
-        allow(RecordSchema).to receive(:roles) { { admin: double(:admin, admin: true) } }
-        allow(controller).to receive(:authenticate_user!) { true }
-        allow(controller).to receive(:current_user) { @user }
-      end
-
-      describe '#index' do
-        let!(:user_set) { FactoryGirl.create(:user_set, name: "Dogs and cats", priority: 5) }
-
-        before :each do
-          allow(controller).to receive(:authenticate_admin!) { true }
-          @normal_user = double(User, user_sets: []).as_null_object
-          allow(User).to receive(:find_by_api_key).with("nonadminkey") { @normal_user }
+      describe 'with an admin account' do
+        before(:each) do
+          @user = FactoryGirl.create(:user, authentication_token: "abc123")
+          allow(RecordSchema).to receive(:roles) { { admin: double(:admin, admin: true) } }
+          allow(controller).to receive(:authenticate_user!) { true }
+          allow(controller).to receive(:current_user) { @user }
         end
 
-        it 'finds all public sets' do
-          expect(UserSet).to receive(:public_sets).with(page: nil) { [] }
-          get :index, format: 'json'
-        end
+        describe '#index' do
+          let!(:user_set) { FactoryGirl.create(:user_set, name: "Dogs and cats", priority: 5) }
 
-        it 'renders the public sets as JSON' do
-          get :index, format: 'json'
-          sets = JSON.parse(response.body)
+          before :each do
+            allow(controller).to receive(:authenticate_admin!) { true }
+            @normal_user = double(User, user_sets: []).as_null_object
+            allow(User).to receive(:find_by_api_key).with("nonadminkey") { @normal_user }
+          end
 
-          sets['sets'].each do |set|
-            expect(set).to have_key 'id'
-            expect(set).to have_key 'name'
-            expect(set).to have_key 'count'
-            expect(set).to have_key 'approved'
-            expect(set).to have_key 'created_at'
-            expect(set).to have_key 'updated_at'
+          it 'finds all public sets' do
+            expect(UserSet).to receive(:public_sets).with(page: nil) { [] }
+            get :index, format: 'json'
+          end
+
+          it 'renders the public sets as JSON' do
+            get :index, format: 'json'
+            sets = JSON.parse(response.body)
+
+            sets['sets'].each do |set|
+              expect(set).to have_key 'id'
+              expect(set).to have_key 'name'
+              expect(set).to have_key 'count'
+              expect(set).to have_key 'approved'
+              expect(set).to have_key 'created_at'
+              expect(set).to have_key 'updated_at'
+            end
           end
         end
       end
+
+      describe 'without an admin account' do
+        it 'renders the appropriate message' do
+          get :index, format: 'json'
+          expect(response.body).to eq '{"errors":"Please provide a API Key"}'
+        end
+      end
+
     end
   end
 end

--- a/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
+# the Department of Internal Affairs. http://digitalnz.org/supplejack
+
+module SupplejackApi
+  module Stories
+    RSpec.describe ModerationsController do
+      routes { SupplejackApi::Engine.routes }
+
+      describe '#index' do
+        it 'finds all public sets' do
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
@@ -6,13 +6,46 @@
 # Supplejack was created by DigitalNZ at the National Library of NZ and
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 
+require 'spec_helper'
+
 module SupplejackApi
   module Stories
-    RSpec.describe ModerationsController do
+    describe ModerationsController do
       routes { SupplejackApi::Engine.routes }
 
+      before(:each) do
+        @user = FactoryGirl.create(:user, authentication_token: "abc123")
+        allow(RecordSchema).to receive(:roles) { { admin: double(:admin, admin: true) } }
+        allow(controller).to receive(:authenticate_user!) { true }
+        allow(controller).to receive(:current_user) { @user }
+      end
+
       describe '#index' do
+        let!(:user_set) { FactoryGirl.create(:user_set, name: "Dogs and cats", priority: 5) }
+
+        before :each do
+          allow(controller).to receive(:authenticate_admin!) { true }
+          @normal_user = double(User, user_sets: []).as_null_object
+          allow(User).to receive(:find_by_api_key).with("nonadminkey") { @normal_user }
+        end
+
         it 'finds all public sets' do
+          expect(UserSet).to receive(:public_sets).with(page: nil) { [] }
+          get :index, format: 'json'
+        end
+
+        it 'renders the public sets as JSON' do
+          get :index, format: 'json'
+          sets = JSON.parse(response.body)
+
+          sets['sets'].each do |set|
+            expect(set).to have_key 'id'
+            expect(set).to have_key 'name'
+            expect(set).to have_key 'count'
+            expect(set).to have_key 'approved'
+            expect(set).to have_key 'created_at'
+            expect(set).to have_key 'updated_at'
+          end
         end
       end
     end

--- a/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
@@ -21,7 +21,7 @@ module SupplejackApi
           allow(controller).to receive(:current_user) { @user }
         end
 
-        describe '#index' do
+        describe '#show' do
           let!(:user_set) { FactoryGirl.create(:user_set, name: "Dogs and cats", priority: 5) }
 
           before :each do
@@ -32,11 +32,11 @@ module SupplejackApi
 
           it 'finds all public sets' do
             expect(UserSet).to receive(:public_sets).with(page: nil) { [] }
-            get :index, format: 'json'
+            get :show, format: 'json'
           end
 
           it 'renders the public sets as JSON' do
-            get :index, format: 'json'
+            get :show, format: 'json'
             sets = JSON.parse(response.body)
 
             sets['sets'].each do |set|
@@ -55,7 +55,7 @@ module SupplejackApi
 
       describe 'without an admin account' do
         it 'renders the appropriate message' do
-          get :index, format: 'json'
+          get :show, format: 'json'
           expect(response.body).to eq '{"errors":"Please provide a API Key"}'
         end
       end

--- a/spec/serializers/supplejack_api/stories_moderation_serializer_spec.rb
+++ b/spec/serializers/supplejack_api/stories_moderation_serializer_spec.rb
@@ -1,0 +1,42 @@
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
+# the Department of Internal Affairs. http://digitalnz.org/supplejack
+
+require 'spec_helper'
+
+module SupplejackApi
+  describe StoriesModerationSerializer do
+    let(:user_set) { FactoryGirl.create(:user_set, name: "Dogs and cats", priority: 5) }
+    let(:serialized_user_set) { StoriesModerationSerializer.new(user_set).as_json[:stories_moderation] }
+
+    describe 'attributes' do
+      it 'renders the id field' do
+        expect(serialized_user_set).to have_key :id
+      end
+
+      it 'renders the name field' do
+        expect(serialized_user_set).to have_key :name
+      end
+
+      it 'renders the count field' do
+        expect(serialized_user_set).to have_key :count
+      end
+
+      it 'renders the approved field' do
+        expect(serialized_user_set).to have_key :approved
+      end
+
+      it 'renders the created_at field' do
+        expect(serialized_user_set).to have_key :created_at
+      end
+
+      it 'renders the updated_at field' do
+        expect(serialized_user_set).to have_key :updated_at
+      end
+    end
+  end
+end
+

--- a/spec/serializers/supplejack_api/stories_moderation_serializer_spec.rb
+++ b/spec/serializers/supplejack_api/stories_moderation_serializer_spec.rb
@@ -21,6 +21,10 @@ module SupplejackApi
         expect(serialized_user_set).to have_key :name
       end
 
+      it 'renders the user field' do
+        expect(serialized_user_set).to have_key :user
+      end
+
       it 'renders the count field' do
         expect(serialized_user_set).to have_key :count
       end


### PR DESCRIPTION
Supplejack API changes that allow the stories that are needing to be moderated to be exposed. 