### PR TITLE
UPDATE PLACE CONCEPTS API

### DIFF
--- a/app/serializers/supplejack_api/concept_serializer.rb
+++ b/app/serializers/supplejack_api/concept_serializer.rb
@@ -41,6 +41,7 @@ module SupplejackApi
 
       include_individual_fields!(hash)
       include_context_fields!(hash)
+      include_place_fields!(hash)
       include_reverse_fields!(hash) if reverse?
       include!(:source_authorities, node: hash) if source_authorities?
       hash
@@ -63,6 +64,14 @@ module SupplejackApi
       hash
     end
 
+    def include_place_fields!(hash)
+      if object.concept_type == 'edm:Agent'
+        hash.except!(:latitude, :longitude, :note)
+      elsif object.concept_type == 'edm:Place'
+        hash.except!(:dateOfBirth, :dateOfDeath, :biographicalInformation)
+      end
+    end
+
     def include_individual_fields!(hash)
       if options[:fields].present?
         options[:fields].push(:concept_id)
@@ -81,7 +90,7 @@ module SupplejackApi
       hash
     end
 
-    def field_value(field)
+    def field_value(field, _options = {})
       value = if ConceptSchema.fields[field].try(:search_value) && ConceptSchema.fields[field].try(:store) == false
                 ConceptSchema.fields[field].search_value.call(object)
               else

--- a/spec/dummy/app/supplejack_api/concept_schema.rb
+++ b/spec/dummy/app/supplejack_api/concept_schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
 # and is licensed under the GNU General Public License, version 3.
 # One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
@@ -19,9 +20,11 @@ class ConceptSchema
   namespace :skos,        url: 'http://www.w3.org/2004/02/skos/core#'
   namespace :xsd,         url: 'http://www.w3.org/2001/XMLSchema#'
   namespace :dc,          url: 'http://purl.org/dc/elements/1.1/'
+  namespace :wgs84,       url: 'http://www.w3.org/2003/01/geo/wgs84_pos#'
 
   # Fields (SourceAuthority fields)
   string      :name
+  string      :title
   string      :prefLabel
   string      :altLabel,                  multi_value: true
   datetime    :dateOfBirth
@@ -32,6 +35,9 @@ class ConceptSchema
   string      :familyName
   integer     :birthYear
   integer     :deathYear
+  string      :note
+  integer     :latitude
+  integer     :longitude
 
   group :source_authorities
   group :reverse
@@ -57,16 +63,20 @@ class ConceptSchema
   end
 
   # Concept
+  # field_options is required if your are storing the field
   model_field :name, field_options: { type: String }, search_as: [:fulltext], search_boost: 6, namespace: :foaf
+  model_field :title, field_options: { type: String }, namespace: :dc
   model_field :prefLabel, field_options: { type: String }, namespace: :skos
   model_field :altLabel, field_options: { type: Array }, search_as: [:fulltext], search_boost: 2, namespace: :skos
   model_field :dateOfBirth, field_options: { type: Date }, namespace: :rdaGr2
   model_field :dateOfDeath, field_options: { type: Date }, namespace: :rdaGr2
   model_field :biographicalInformation, field_options: { type: String }, search_as: [:fulltext], search_boost: 1,  namespace: :rdaGr2
   model_field :sameAs, field_options: { type: Array }, namespace: :owl
+  model_field :note, field_options: { type: String }, namespace: :wgs84
+  model_field :latitude, field_options: { type: Integer }, namespace: :wgs84
+  model_field :longitude, field_options: { type: Integer }, namespace: :wgs84
 
   # Use store: false to display the fields in the /schema
-  model_field :title, store: false, namespace: :dc
   model_field :date, store: false, namespace: :dc
   model_field :description, store: false, namespace: :dc
   model_field :agents, store: false, namespace: :edm

--- a/spec/factories/concepts.rb
+++ b/spec/factories/concepts.rb
@@ -11,6 +11,17 @@ module SupplejackApi
       concept_id    1
       concept_type  'edm:Agent'
       name          'Colin McCahon'
+      biographicalInformation 'Bio'
+      dateOfBirth   1991
+      dateOfDeath   1992
+      note          'Concept is a Est mollitia neque magnam id. Doloremque et et consectetur et aut. In voluptas sunt et ut aut.'
+      latitude      -38.1368478
+      longitude     176.2497461
+      title         'Title'
+    end
+
+    trait :place do
+      concept_type  'edm:Place'
     end
   end
 end

--- a/spec/serializers/supplejack_api/concept_serializer_spec.rb
+++ b/spec/serializers/supplejack_api/concept_serializer_spec.rb
@@ -41,9 +41,6 @@ module SupplejackApi
               :name => {
                 '@id' => 'foaf:name'
               },
-              :title => {
-                '@id' => 'dc:title'
-              },
               :date => {
                 '@id' => 'dc:date'
               },
@@ -67,6 +64,18 @@ module SupplejackApi
         s.include_context_fields!(@hash)
         expect(@hash['@context']).to eq "#{ENV['HTTP_HOST']}/schema"
         expect(@hash[:name]).to eq 'McCahon'
+      end
+    end
+
+    describe '#include_place_fields!' do
+      context 'emd:Agent' do
+        it 'shows the :biographicalInformation, :dateOfBirth, and :dateOfDeath fields'
+        it 'does not show the :note, :latitude, and :longitude fields'
+      end
+
+      context 'edm:Place' do
+        it 'shows the :note, :latitude, and :longitude fields'
+        it 'does not show the :biographicalInformation, :dateOfBirth, and :dateOfDeath fields'
       end
     end
 


### PR DESCRIPTION
Acceptance Criteria
=================

note, latitude, longitude fields are returned for Place concepts API calls
http://api.dnz0a.digitalnz.org/concepts/4044.json?api_key=API_KEY
http://api.dnz0a.digitalnz.org/schema updated with new context (specified below)
Answer question below
Questions
Should Concepts show different fields relevant to the concept_type.
eg dont show dateOfBirth, biographicalInformation on http://api.dnz0a.digitalnz.org/concepts/4044.json?api_key=API_KEY
and equivalently dont show lat long info on People

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] All Tests are Passing
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Linters Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)