### PR TITLE
RENAME EMBED SUBTYPE FROM DNZ TO RECORD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,26 +13,25 @@ source 'http://rubygems.org'
 # development dependencies will be added by default to the :development group.
 gemspec
 
-# jquery-rails is used by the dummy application
-gem 'jquery-rails'
-
 # Xml doesn't get support in AMS, this is an existing fork
 gem 'active_model_serializers', git: 'https://github.com/boost/active_model_serializers'
+gem 'codeclimate-test-reporter', group: :test, require: nil
+gem 'cucumber-rails', require: false
+gem 'dimensions', require: false
+gem 'factory_girl_rails', require: false
+# jquery-rails is used by the dummy application
+gem 'jquery-rails'
+gem 'mimemagic', require: false
 gem 'mongoid_auto_inc', git: 'https://github.com/boost/mongoid_auto_inc.git'
-
 # Must add 'require' statments in Gemfile
 gem 'mongoid-tree', require: 'mongoid/tree'
-gem 'dimensions', require: false
-gem 'mimemagic', require: false
 gem 'rb-fsevent', require: false
-gem 'cucumber-rails', require: false
-gem 'factory_girl_rails', require: false
+gem 'rubocop', require: false
 gem 'simplecov', require: false
 gem 'yard', require: false, group: :development
 # This is a gem created by fedegl to test the XML responses, its part of the Boost github organization account
 gem 'xml_spec', git: 'https://github.com/boost/xml_spec', require: false
-gem 'codeclimate-test-reporter', group: :test, require: nil
-gem 'rubocop', require: false
+
 group :test do
   gem 'faker'
   gem 'json-schema'

--- a/app/controllers/supplejack_api/set_items_controller.rb
+++ b/app/controllers/supplejack_api/set_items_controller.rb
@@ -17,7 +17,7 @@ module SupplejackApi
     def create
       # This ugly fix should be removed when digitalnz.org is decommissioned
       updated_params = record_params.merge(type: 'embed',
-                                           sub_type: 'dnz',
+                                           sub_type: 'record',
                                            content: { record_id: record_params[:record_id] },
                                            meta: { align_mode: 0 })
 

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -132,7 +132,7 @@ module SupplejackApi::Concerns::UserSet
               set_item_hash.symbolize_keys!
               # This ugly fix should be removed when digitalnz.org is decommissioned
               params = set_item_hash.merge(record_id: set_item_hash[:record_id], type: 'embed',
-                                           sub_type: 'dnz', content: { record_id: set_item_hash[:record_id] },
+                                           sub_type: 'record', content: { record_id: set_item_hash[:record_id] },
                                            meta: { align_mode: 0 })
 
               # set_item = self.set_items.find_or_initialize_by(params)

--- a/app/serializers/supplejack_api/stories_moderation_serializer.rb
+++ b/app/serializers/supplejack_api/stories_moderation_serializer.rb
@@ -8,6 +8,6 @@
 
 module SupplejackApi
   class StoriesModerationSerializer < ActiveModel::Serializer
-    attributes :id, :name, :user, :count, :approved, :created_at, :updated_at
+    attributes :id, :name, :user, :count, :approved, :featured, :created_at, :updated_at
   end
 end

--- a/app/services/stories_api/v3/helpers.rb
+++ b/app/services/stories_api/v3/helpers.rb
@@ -28,7 +28,7 @@ module StoriesApi
       def first_suitable_image(story)
         item_with_image = story.set_items.sort_by(&:position).detect do |item|
           item.content.present? && (item.type == 'embed') &&
-            (item.sub_type == 'dnz') && item.content[:image_url].present?
+            (item.sub_type == 'record') && item.content[:image_url].present?
         end
 
         item_with_image.content[:image_url] unless item_with_image.nil?

--- a/app/services/stories_api/v3/presenters/content/embed/record.rb
+++ b/app/services/stories_api/v3/presenters/content/embed/record.rb
@@ -4,7 +4,7 @@ module StoriesApi
     module Presenters
       module Content
         module Embed
-          class Dnz
+          class Record
             RECORD_FIELDS = {
               title: :title,
               display_collection: :display_collection,

--- a/app/services/stories_api/v3/schemas/story_item/block.rb
+++ b/app/services/stories_api/v3/schemas/story_item/block.rb
@@ -16,7 +16,7 @@ module StoriesApi
           end
 
           def valid_sub_types
-            %w(dnz heading rich-text)
+            %w(record heading rich-text)
           end
 
           define! do

--- a/app/services/stories_api/v3/schemas/story_item/embed/record.rb
+++ b/app/services/stories_api/v3/schemas/story_item/embed/record.rb
@@ -11,7 +11,7 @@ module StoriesApi
     module Schemas
       module StoryItem
         module Embed
-          Dnz = Dry::Validation.Schema(Block) do
+          Record = Dry::Validation.Schema(Block) do
             configure do
               def valid_alignments
                 %w(left center right)

--- a/spec/controllers/supplejack_api/set_items_controller_spec.rb
+++ b/spec/controllers/supplejack_api/set_items_controller_spec.rb
@@ -24,7 +24,7 @@ module SupplejackApi
     describe "POST 'create'" do
       it 'creates the set item through the @user_set' do
         create(:record_with_fragment, record_id: 12345)
-        expect(@user_set.set_items).to receive(:build).with({"record_id"=>"12345", "type"=>"embed", "sub_type"=>"dnz", "content"=>{"record_id"=>"12345"}, "meta"=>{"align_mode"=>0}}) { @set_item }
+        expect(@user_set.set_items).to receive(:build).with({"record_id"=>"12345", "type"=>"embed", "sub_type"=>"record", "content"=>{"record_id"=>"12345"}, "meta"=>{"align_mode"=>0}}) { @set_item }
         expect(@user_set).to receive(:save).and_return(true)
         post :create, user_set_id: @user_set.id, record: { record_id: '12345' }, format: :json
       end

--- a/spec/controllers/supplejack_api/story_items_controller_spec.rb
+++ b/spec/controllers/supplejack_api/story_items_controller_spec.rb
@@ -103,7 +103,7 @@ module SupplejackApi
         it 'should return error for unknow values for sub type' do
           post :create, story_id: story.id.to_s, api_key: api_key, user_key: api_key, item: { type: 'text', sub_type: 'foo' }
           expect(response.status).to eq 400
-          expect(JSON.parse(response.body)['errors']).to eq 'Unsupported Values: sub_type must be one of: dnz, heading, rich-text'
+          expect(JSON.parse(response.body)['errors']).to eq 'Unsupported Values: sub_type must be one of: record, heading, rich-text'
         end
 
         it 'should return error if content and meta is not posted' do

--- a/spec/factories/story_blocks.rb
+++ b/spec/factories/story_blocks.rb
@@ -33,7 +33,7 @@ FactoryGirl.define do
       end
 
       type 'embed'
-      sub_type 'dnz'
+      sub_type 'record'
       content {{
         id: id,
         record: {

--- a/spec/factories/story_item.rb
+++ b/spec/factories/story_item.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
       end
 
       type 'embed'
-      sub_type 'dnz'
+      sub_type 'record'
       content {{
         id: id,
         record: {

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -338,8 +338,8 @@ module SupplejackApi
 
       it "can replace the set items" do
         user_set.save
-        user_set.set_items.create(record_id: 13, :type=>"embed", :sub_type=>"dnz", :content=>{:record_id=>"13"}, :meta=>{:align_mode=>0})
-        user_set.update_attributes_and_embedded(records: [{"record_id" => "13", "position" => nil, :type=>"embed", :sub_type=>"dnz", :content=>{:record_id=>"13"}, :meta=>{:align_mode=>0}}])
+        user_set.set_items.create(record_id: 13, :type=>"embed", :sub_type=>"record", :content=>{:record_id=>"13"}, :meta=>{:align_mode=>0})
+        user_set.update_attributes_and_embedded(records: [{"record_id" => "13", "position" => nil, :type=>"embed", :sub_type=>"record", :content=>{:record_id=>"13"}, :meta=>{:align_mode=>0}}])
         user_set.reload
         expect(user_set.set_items.size).to eq 1
         expect(user_set.set_items.first.record_id).to eq 13

--- a/spec/services/stories_api/v3/endpoints/story_item_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_item_spec.rb
@@ -134,7 +134,7 @@ module StoriesApi
 
         describe '#patch' do
           it 'fails with no content id error' do
-            item = create(:story_item, type: 'embed', sub_type: 'dnz', position: 1,
+            item = create(:story_item, type: 'embed', sub_type: 'record', position: 1,
                           content: { title: 'Title', display_collection: 'Marama', value: 'bar',
                                      category: ['Te Papa'], image_url: 'url', tags: %w(foo bar)},
                           meta: { size: 1, metadata: 'Some Meta' }).attributes.symbolize_keys
@@ -150,7 +150,7 @@ module StoriesApi
           end
 
           it 'fails with content must be an intiger error' do
-            item = create(:story_item, type: 'embed', sub_type: 'dnz', position: 1,
+            item = create(:story_item, type: 'embed', sub_type: 'record', position: 1,
                           content: { id: "zfkjg"},
                           meta: { size: 1, metadata: 'Some Meta' }).attributes.symbolize_keys
             item.delete(:_id)
@@ -166,7 +166,7 @@ module StoriesApi
 
           it 'updates given set item' do
             record = create(:record)
-            item = create(:story_item, type: 'embed', sub_type: 'dnz', position: 1,
+            item = create(:story_item, type: 'embed', sub_type: 'record', position: 1,
                           content: { id: record.record_id},
                           meta: { size: 1, metadata: 'Some Meta' }).attributes.symbolize_keys
             item.delete(:_id)
@@ -185,7 +185,7 @@ module StoriesApi
             let(:record) { create(:record) }
 
             it 'updates cover thumbnail of story if meta is_cover true' do
-              item = create(:story_item, type: 'embed', sub_type: 'dnz', position: 1,
+              item = create(:story_item, type: 'embed', sub_type: 'record', position: 1,
                             content: { id: record.record_id},
                             meta: { size: 1, metadata: 'Some Meta', is_cover: true}).attributes.symbolize_keys
 
@@ -199,7 +199,7 @@ module StoriesApi
             end
 
             it 'updates cover thumbnail of story as nil if meta is_cover false' do
-              item = create(:story_item, type: 'embed', sub_type: 'dnz', position: 1,
+              item = create(:story_item, type: 'embed', sub_type: 'record', position: 1,
                             content: { id: record.record_id},
                             meta: { size: 1, metadata: 'Some Meta', is_cover: false}).attributes.symbolize_keys
               @story.update_attribute(:cover_thumbnail, @story.set_items.first.content[:image_url])

--- a/spec/services/stories_api/v3/endpoints/story_items_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_items_spec.rb
@@ -89,7 +89,7 @@ module StoriesApi
               record = create(:record)
               @story = create(:story)
               @user = @story.user
-              @item = create(:story_item, type: 'embed', sub_type: 'dnz', 
+              @item = create(:story_item, type: 'embed', sub_type: 'record', 
                              position: 1, # This value is the index for the array of set items. ie position 2
                              content: { id: record.record_id }, meta: {}).attributes.symbolize_keys
               
@@ -129,7 +129,7 @@ module StoriesApi
 
             it 'should return error when type is missing' do
               response = StoryItems.new(story_id: @story.id, user_key: @user.api_key,
-                                        item: { sub_type: 'dnz', meta: {} }).post
+                                        item: { sub_type: 'record', meta: {} }).post
               expect(response).to eq(
                 status: 400,
                 exception: {
@@ -151,7 +151,7 @@ module StoriesApi
 
             it 'should return error when content is missing' do
               response = StoryItems.new(story_id: @story.id, user_key: @user.api_key,
-                                        item: { type: 'embed', sub_type: 'dnz', meta: {} }).post
+                                        item: { type: 'embed', sub_type: 'record', meta: {} }).post
 
               expect(response).to eq(
                 status: 400,
@@ -162,7 +162,7 @@ module StoriesApi
             end
 
             it 'should return error when type is not valid' do
-              item = create(:story_item, type: 'youtube', sub_type: 'dnz', content: {}, meta: {}).attributes.symbolize_keys
+              item = create(:story_item, type: 'youtube', sub_type: 'record', content: {}, meta: {}).attributes.symbolize_keys
               item.delete(:_id)
 
               response = StoryItems.new(story_id: @story.id, user_key: @user.api_key,
@@ -186,7 +186,7 @@ module StoriesApi
               expect(response).to eq(
                 status: 400,
                 exception: {
-                  message: 'Unsupported Values: sub_type must be one of: dnz, heading, rich-text'
+                  message: 'Unsupported Values: sub_type must be one of: record, heading, rich-text'
                 }
               )
             end
@@ -233,7 +233,7 @@ module StoriesApi
             context 'embed item' do
               before do
                 record = create(:record)
-                factory = create(:story_item, type: 'embed', sub_type: 'dnz',
+                factory = create(:story_item, type: 'embed', sub_type: 'record',
                                              content: { id: record.record_id},
                                              meta: { metadata: 'Some Meta' })
 
@@ -288,7 +288,7 @@ module StoriesApi
 
               it 'updates the cover thumbnail if it dosent exist' do
                 @story.update_attribute(:cover_thumbnail, nil)
-                factory = create(:story_item, type: 'embed', sub_type: 'dnz',
+                factory = create(:story_item, type: 'embed', sub_type: 'record',
                              content: { id: record.record_id},
                              meta: { metadata: 'Some Meta' })
 

--- a/spec/services/stories_api/v3/presenters/content/embed/record_spec.rb
+++ b/spec/services/stories_api/v3/presenters/content/embed/record_spec.rb
@@ -3,7 +3,7 @@ module StoriesApi
     module Presenters
       module Content
         module Embed
-          RSpec.describe Dnz do
+          RSpec.describe Record do
             let(:record) {create(:record_with_fragment)}
             let(:block) {create(:embed_dnz_item, id: record.record_id)}
             let(:result) {subject.call(block)}

--- a/spec/services/stories_api/v3/schemas/story_item/embed/record_spec.rb
+++ b/spec/services/stories_api/v3/schemas/story_item/embed/record_spec.rb
@@ -3,7 +3,7 @@ module StoriesApi
     module Schemas
       module StoryItem
         module Embed
-          RSpec.describe Dnz do
+          RSpec.describe Record do
             let(:valid_block) { build(:embed_dnz_block) }
 
             def update_content_value(field, value)


### PR DESCRIPTION
Why  : There shouldnt be any eference of dnz in opensource code base
What : Renaming dnz sub_type to record