### PR TITLE
Admin features on stories patch request

### DIFF
--- a/app/services/stories_api/v3/endpoints/story.rb
+++ b/app/services/stories_api/v3/endpoints/story.rb
@@ -36,7 +36,7 @@ module StoriesApi
         end
 
         def patch
-          story = if RecordSchema.roles[@user.role.to_sym].try(:admin)
+          story = if @user.admin?
                     ::SupplejackApi::UserSet.custom_find(params[:id])
                   else
                     strip_admin_params
@@ -65,8 +65,10 @@ module StoriesApi
           create_response(status: 204)
         end
 
+        private
+
         def strip_admin_params
-          [:approved, :featured].map do |field|
+          [:approved, :featured].each do |field|
             @params[:story].delete(field) if @params[:story].present?
           end
         end

--- a/app/services/stories_api/v3/endpoints/story.rb
+++ b/app/services/stories_api/v3/endpoints/story.rb
@@ -43,7 +43,6 @@ module StoriesApi
                     @user.user_sets.custom_find(params[:id])
                   end
 
-
           return create_error('StoryNotFound', id: params[:id]) unless story.present?
 
           merge_patch = PerformMergePatch.new(::StoriesApi::V3::Schemas::Story, ::StoriesApi::V3::Presenters::Story.new)

--- a/spec/services/stories_api/v3/endpoints/story_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_spec.rb
@@ -162,6 +162,38 @@ module StoriesApi
               expect(updated_story.subjects).to eq(patch[:subjects])
               expect(updated_story.tags).to eq(patch[:tags])
             end
+
+            it 'cannot be updated by a non admin user' do
+              updated_story = SupplejackApi::UserSet.custom_find(story.id)
+
+              expect(updated_story.approved).to be false
+              expect(updated_story.featured).to be false
+            end
+          end
+
+          context 'admin fields' do
+            let(:user) { create(:admin_user) }
+
+            let(:patch) do
+              {
+                description: 'foobar',
+                tags: ['tags', 'go', 'here'],
+                subjects: ['subjects', 'go', 'here'],
+                approved: true,
+                featured: true,
+              }
+            end
+            let(:response) { Story.new(id: story.id, story: patch, user_key: user.authentication_token).patch }
+
+            context
+
+            it 'can be updated by and admin user' do
+              updated_story = SupplejackApi::UserSet.custom_find(story.id)
+
+              expect(updated_story.approved).to be true
+              expect(updated_story.featured).to be true
+            end
+
           end
         end
       end

--- a/spec/services/stories_api/v3/endpoints/story_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_spec.rb
@@ -185,8 +185,6 @@ module StoriesApi
             end
             let(:response) { Story.new(id: story.id, story: patch, user_key: user.authentication_token).patch }
 
-            context
-
             it 'can be updated by and admin user' do
               updated_story = SupplejackApi::UserSet.custom_find(story.id)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,6 @@ RSpec.configure do |config|
       klass = "#{model.capitalize}Schema".constantize
 
       allow(klass).to receive(:default_role) { double(:role, name: :developer) }
-      allow(klass).to receive_message_chain(:roles, :keys) { [:developer] }
     end
   end
 


### PR DESCRIPTION
*Acceptance Criteria*
- Stories moderation page is efficient and effective using the Stories API only (not the Sets API)

Currently the moderations page in kereru uses UserSet functionality, which is bad practice.  This is resulting multiple unnecessary api calls each time and admin ticks a box on the admin page. 

Changes required:
story admin  controller on  sj api
story admin method in sj client
clean up of moderations controller in kereru


NOTES: 
To update approved / featured, you need to be an api admin(api_key).  User sets are found, before being updated, by checking if the user is an admin, then finding by set id.  If not admin, then the set is found by looking up users sets, then finding by user set id.  Strange but true.  

DNZ finds usersets for moderation by sending admin api key, then it has the power to update it. 

The stories end point just uses the id to find the story, and updates it via permission granted with the story owners user_key .   There is no facility to update approved / featured fields (admin fields) on the stories endpoint.