### PR TITLE
Add new fields to story item presenter and record presenter

### DIFF
--- a/app/services/stories_api/v3/presenters/content/embed/record.rb
+++ b/app/services/stories_api/v3/presenters/content/embed/record.rb
@@ -13,7 +13,10 @@ module StoriesApi
               landing_url: :landing_url,
               tags: :tag,
               description: :description,
-              content_partner: :content_partner
+              content_partner: :content_partner,
+              creator: :creator,
+              rights: :rights,
+              contributing_partner: :contributing_partner
             }.freeze
 
             def call(block)

--- a/spec/dummy/app/supplejack_api/record_schema.rb
+++ b/spec/dummy/app/supplejack_api/record_schema.rb
@@ -25,7 +25,10 @@ class RecordSchema
   string    :display_collection,                                search_as: [:filter, :fulltext],  namespace: :sj
   string    :tag,         multi_value: true,      search_as: [:filter]
   string    :description,                         search_boost: 2,      search_as: [:filter, :fulltext],  namespace: :dc
+  string    :rights,                              search_as: [:filter], namespace: :dc
   string    :content_partner, multi_value: true,                                                          namespace: :dc
+  string    :creator,     multi_value: true,    search_as: [:filter, :fulltext],  namespace: :dc
+  string    :contributing_partner,  multi_value: true,    search_as: [:fulltext], namespace: :dc
 
   # facets
   string    :category,     multi_value: true,     search_as: [:filter]

--- a/spec/services/stories_api/v3/presenters/content/embed/record_spec.rb
+++ b/spec/services/stories_api/v3/presenters/content/embed/record_spec.rb
@@ -25,7 +25,7 @@ module StoriesApi
             end
 
             it 'presents the record fields' do
-              [:title, :display_collection, :category, :image_url, :landing_url, :tags, :content_partner].each do |key|
+              [:title, :display_collection, :category, :image_url, :landing_url, :tags, :content_partner, :creator, :contributing_partner, :rights].each do |key|
                 expect(result).to have_key(key)
               end
             end

--- a/spec/services/stories_api/v3/presenters/story_item_spec.rb
+++ b/spec/services/stories_api/v3/presenters/story_item_spec.rb
@@ -23,6 +23,7 @@ module StoriesApi
             let(:story_item) {build(:embed_dnz_item, id: record.record_id)}
 
             it 'hands off the content field to the custom presenter' do
+            # FIXME This test isn't testing anything.  It is testing that nil is nil, because the key is not present on the hash or the record
               expect(presented_json[:content][:description]).to eq(record.description)
               expect(presented_json[:content][:title]).to eq(record.title)
             end


### PR DESCRIPTION
The following fields are required in the story json response: 
```
:creator
:rights
:contributing_partner
```