### PR TITLE
Fix missing cover thumbnails

### DIFF
--- a/app/services/stories_api/v3/endpoints/story_item.rb
+++ b/app/services/stories_api/v3/endpoints/story_item.rb
@@ -52,11 +52,12 @@ module StoriesApi
 
         def delete
           return @errors if @errors
+          item.delete
+
           if story.cover_thumbnail == item.content[:image_url]
             story.update_attribute(:cover_thumbnail, first_suitable_image(story))
           end
 
-          item.delete
 
           create_response(status: 204)
         end

--- a/app/services/stories_api/v3/endpoints/story_item.rb
+++ b/app/services/stories_api/v3/endpoints/story_item.rb
@@ -52,7 +52,9 @@ module StoriesApi
 
         def delete
           return @errors if @errors
-          story.update_attribute(:cover_thumbnail, first_suitable_image(story)) if story.cover_thumbnail == item.content[:image_url]
+          if story.cover_thumbnail == item.content[:image_url]
+            story.update_attribute(:cover_thumbnail, first_suitable_image(story))
+          end
 
           item.delete
 

--- a/app/services/stories_api/v3/endpoints/story_item.rb
+++ b/app/services/stories_api/v3/endpoints/story_item.rb
@@ -52,7 +52,7 @@ module StoriesApi
 
         def delete
           return @errors if @errors
-          story.update_attribute(:cover_thumbnail, nil) if story.cover_thumbnail == item.content[:image_url]
+          story.update_attribute(:cover_thumbnail, first_suitable_image(story)) if story.cover_thumbnail == item.content[:image_url]
 
           item.delete
 

--- a/app/services/stories_api/v3/endpoints/story_item.rb
+++ b/app/services/stories_api/v3/endpoints/story_item.rb
@@ -58,7 +58,6 @@ module StoriesApi
             story.update_attribute(:cover_thumbnail, first_suitable_image(story))
           end
 
-
           create_response(status: 204)
         end
 

--- a/app/services/stories_api/v3/helpers.rb
+++ b/app/services/stories_api/v3/helpers.rb
@@ -24,7 +24,6 @@ module StoriesApi
         response
       end
 
-      # This method is not used now. Because cover thumb selection on sorting has been disabled
       def first_suitable_image(story)
         item_with_image = story.set_items.sort_by(&:position).detect do |item|
           item.content.present? && (item.type == 'embed') &&

--- a/spec/controllers/supplejack_api/story_item_moves_controller_spec.rb
+++ b/spec/controllers/supplejack_api/story_item_moves_controller_spec.rb
@@ -15,8 +15,8 @@ module SupplejackApi
           )
         end
         let(:ordered_items) { story.set_items.sort_by(&:position) }
-        let(:first_title) { ordered_items.first.content[:record][:title] }
-        let(:last_title) { ordered_items.last.content[:record][:title] }
+        let(:first_title) { ordered_items.first.content[:title] }
+        let(:last_title) { ordered_items.last.content[:title] }
 
         before do
           post :create, {story_id: story.id, item_id: story.set_items.first.id, position: story.set_items.last.id, api_key: story.user.api_key, user_key: story.user.api_key}

--- a/spec/factories/story_item.rb
+++ b/spec/factories/story_item.rb
@@ -38,13 +38,11 @@ FactoryGirl.define do
       sub_type 'record'
       content {{
         id: id,
-        record: {
-          title: title,
-          display_collection: display_collection,
-          category: category,
-          image_url: image_url,
-          tags: tags
-        }
+        title: title,
+        display_collection: display_collection,
+        category: category,
+        image_url: image_url,
+        tags: tags
       }}
       meta {{
         alignment: alignment,

--- a/spec/services/stories_api/v3/endpoints/story_item_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_item_spec.rb
@@ -121,14 +121,16 @@ module StoriesApi
             )
           end
 
-          it 'updates the story cover_thumbanil as nil if the item has same image_url' do
-            expect(@story.cover_thumbnail).to be_truthy # ie not nil
+          it 'updates the story cover_thumbanil to new image and not to be nil' do
+            # Add two dnz embed items to the story that both have image_urls
+            2.times { @story.set_items.create(attributes_for(:embed_dnz_item)) }
+            @story.save!
 
-            @story.update_attribute(:cover_thumbnail, @story.set_items.first.content[:image_url])
-            StoryItem.new(id: @story.set_items.first.id.to_s, story_id: @story.id, user_key: @user.api_key).delete
+            @story.update_attribute(:cover_thumbnail, @story.set_items.last.content[:image_url])
+            StoryItem.new(id: @story.set_items.last.id.to_s, story_id: @story.id, user_key: @user.api_key).delete
             @story.reload
 
-            expect(@story.cover_thumbnail).to be_nil
+            expect(@story.cover_thumbnail).to_not be_nil
           end
         end
 


### PR DESCRIPTION
Deleting a story item resulting in the story cover thumbnail being reset to nil, which was incorrect.  Now, it is reset to the next suitable image_url