### PR TITLE
Gm/user end point

### DIFF
--- a/app/controllers/supplejack_api/users_controller.rb
+++ b/app/controllers/supplejack_api/users_controller.rb
@@ -10,7 +10,7 @@
 module SupplejackApi
   class UsersController < ApplicationController
     respond_to :xml, :json
-    before_action :authenticate_admin!, except: :show
+    before_action :authenticate_admin!
 
     def show
       @user = User.custom_find(params[:id])

--- a/spec/controllers/supplejack_api/users_controller_spec.rb
+++ b/spec/controllers/supplejack_api/users_controller_spec.rb
@@ -12,10 +12,10 @@ module SupplejackApi
     routes { SupplejackApi::Engine.routes }
 
     context 'admin user' do
-      let(:user) { FactoryGirl.create(:admin_user, authentication_token: 'abc123') }
+      let(:user) { create(:admin_user, authentication_token: 'abc123') }
 
       describe 'GET show' do
-        it 'should assign @user when api key belongs to an admin' do
+        it 'should assign @user' do
           get :show, id: user.id, api_key: 'abc123', format: :json
           expect(assigns(:user)).to eq(user)
         end
@@ -31,7 +31,7 @@ module SupplejackApi
 
       describe 'PUT update' do
         it 'updates the user attributes' do
-          user_params = FactoryGirl.attributes_for(:user, name: 'Richard')
+          user_params = attributes_for(:user, name: 'Richard')
           patch :update, id: user.api_key, api_key: user.authentication_token, user: user_params
           user.reload
           expect(user.name).to eq 'Richard'
@@ -40,6 +40,9 @@ module SupplejackApi
 
       describe 'DELETE destroy' do
         it 'destroys the user' do
+          user.save!
+          expect(User.count).to eq 1
+
           delete :destroy, id: user.id, api_key: user.authentication_token
           expect(User.count).to eq 0
         end
@@ -47,32 +50,32 @@ module SupplejackApi
     end
 
     context 'not an admin user' do
-      let(:user) { FactoryGirl.create(:user, authentication_token: 'abc123') }
+      let(:user) { create(:user, authentication_token: 'abc123') }
 
       describe 'GET show' do
-        it 'returns status forbidden when api key does not belongs to an admin' do
+        it 'returns status forbidden' do
           get :show, id: user.id, api_key: 'abc123', format: :json
           expect(response).to have_http_status(:forbidden)
         end
       end
 
       describe 'POST create' do
-        it 'returns status forbidden when api key does not belongs to an admin' do
+        it 'returns status forbidden' do
           post :create, api_key: 'abc123', user: { name: 'Ben' }, format: 'json'
           expect(response).to have_http_status(:forbidden)
         end
       end
 
       describe 'PUT update' do
-        it 'returns status forbidden when api key does not belongs to an admin' do
-          user_params = FactoryGirl.attributes_for(:user, name: 'Richard')
+        it 'returns status forbidden' do
+          user_params = attributes_for(:user, name: 'Richard')
           patch :update, id: user.api_key, api_key: user.authentication_token, user: user_params
           expect(response).to have_http_status(:forbidden)
         end
       end
 
       describe 'DELETE destroy' do
-        it 'returns status forbidden when api key does not belongs to an admin' do
+        it 'returns status forbidden' do
           delete :destroy, id: user.id, api_key: user.authentication_token
           expect(response).to have_http_status(:forbidden)
         end

--- a/spec/controllers/supplejack_api/users_controller_spec.rb
+++ b/spec/controllers/supplejack_api/users_controller_spec.rb
@@ -11,36 +11,71 @@ module SupplejackApi
   describe UsersController, type: :controller do
     routes { SupplejackApi::Engine.routes }
 
-    let(:user) { FactoryGirl.create(:user, authentication_token: 'abc123', role: 'admin') }
+    context 'admin user' do
+      let(:user) { FactoryGirl.create(:admin_user, authentication_token: 'abc123') }
 
-    describe 'GET show' do
-      it 'should assign @user' do
-        get :show, id: user.id, api_key: 'abc123', format: :json
-        expect(assigns(:user)).to eq(user)
+      describe 'GET show' do
+        it 'should assign @user when api key belongs to an admin' do
+          get :show, id: user.id, api_key: 'abc123', format: :json
+          expect(assigns(:user)).to eq(user)
+        end
+      end
+
+      describe 'POST create' do
+        it 'should create a new user' do
+          allow(RecordSchema).to receive(:roles) { { admin: double(:admin, admin: true) } }
+          expect(User).to receive(:create).with({ 'name' => 'Ben' }).and_return(user)
+          post :create, api_key: 'abc123', user: { name: 'Ben' }, format: 'json'
+        end
+      end
+
+      describe 'PUT update' do
+        it 'updates the user attributes' do
+          user_params = FactoryGirl.attributes_for(:user, name: 'Richard')
+          patch :update, id: user.api_key, api_key: user.authentication_token, user: user_params
+          user.reload
+          expect(user.name).to eq 'Richard'
+        end
+      end
+
+      describe 'DELETE destroy' do
+        it 'destroys the user' do
+          delete :destroy, id: user.id, api_key: user.authentication_token
+          expect(User.count).to eq 0
+        end
       end
     end
 
-    describe 'POST create' do
-      it 'should create a new user' do
-        allow(RecordSchema).to receive(:roles) { { admin: double(:admin, admin: true) } }
-        expect(User).to receive(:create).with({ 'name' => 'Ben' }).and_return(user)
-        post :create, api_key: 'abc123', user: { name: 'Ben' }, format: 'json'
-      end
-    end
+    context 'not an admin user' do
+      let(:user) { FactoryGirl.create(:user, authentication_token: 'abc123') }
 
-    describe 'PUT update' do
-      it 'updates the user attributes' do
-        user_params = FactoryGirl.attributes_for(:user, name: 'Richard')
-        patch :update, id: user.api_key, api_key: user.authentication_token, user: user_params
-        user.reload
-        expect(user.name).to eq 'Richard'
+      describe 'GET show' do
+        it 'returns status forbidden when api key does not belongs to an admin' do
+          get :show, id: user.id, api_key: 'abc123', format: :json
+          expect(response).to have_http_status(:forbidden)
+        end
       end
-    end
 
-    describe 'DELETE destroy' do
-      it 'destroys the user' do
-        delete :destroy, id: user.id, api_key: user.authentication_token
-        expect(User.count).to eq 0
+      describe 'POST create' do
+        it 'returns status forbidden when api key does not belongs to an admin' do
+          post :create, api_key: 'abc123', user: { name: 'Ben' }, format: 'json'
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      describe 'PUT update' do
+        it 'returns status forbidden when api key does not belongs to an admin' do
+          user_params = FactoryGirl.attributes_for(:user, name: 'Richard')
+          patch :update, id: user.api_key, api_key: user.authentication_token, user: user_params
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      describe 'DELETE destroy' do
+        it 'returns status forbidden when api key does not belongs to an admin' do
+          delete :destroy, id: user.id, api_key: user.authentication_token
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
   end


### PR DESCRIPTION
Acceptance Criteria
=================

- /users endpoint is only accessible with admin api_keys
- Determine where this is being used to make sure that we don't break things.
- If it's not in use remove the endpoint.

Background
=================
Supplejack client does use the users#show endpoint, therefore we cannot remove this action.

In order to make the User data more secure we are requiring admin privilege to access the `UsersController#show` action.

We also improved the test coverage in the Users Controller to cover admin and non admin scenario

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] All Tests are Passing
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Linters Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)