### PR TITLE
RECORDS WITH NO TITLES BREAK STORIES AND TE: As a PO I want records with no title metadata to not break Stories, so that Stories and Topics work with these records

### DIFF
--- a/app/services/stories_api/v3/presenters/content/embed/record.rb
+++ b/app/services/stories_api/v3/presenters/content/embed/record.rb
@@ -31,6 +31,8 @@ module StoriesApi
                 result[name] = record&.public_send(field)
               end
 
+              result[:title] = 'Untitled' if result[:title].nil?
+
               result[:image_url] = record&.thumbnail_url if result[:image_url].nil?
 
               # FIXME

--- a/spec/services/stories_api/v3/presenters/content/embed/record_spec.rb
+++ b/spec/services/stories_api/v3/presenters/content/embed/record_spec.rb
@@ -44,6 +44,16 @@ module StoriesApi
                 expect(result[:image_url]).to eq record.thumbnail_url
               end
             end
+
+            context 'no title' do
+              let(:record) { create(:record, title: nil) }
+              let(:block) {create(:embed_dnz_item, id: record.record_id)}
+              let(:result) {subject.call(block)}
+
+              it 'says Untitled if the title is nil' do
+                expect(result[:title]).to eq 'Untitled'
+              end
+            end
           end
         end
       end

--- a/spec/services/stories_api/v3/presenters/story_item_spec.rb
+++ b/spec/services/stories_api/v3/presenters/story_item_spec.rb
@@ -25,7 +25,7 @@ module StoriesApi
             it 'hands off the content field to the custom presenter' do
             # FIXME This test isn't testing anything.  It is testing that nil is nil, because the key is not present on the hash or the record
               expect(presented_json[:content][:description]).to eq(record.description)
-              expect(presented_json[:content][:title]).to eq(record.title)
+              expect(presented_json[:content][:title]).to eq('Untitled')
             end
           end
         end


### PR DESCRIPTION
** Acceptance Criteria **

- TE and Stories with title'less records work correctly
- The API always worked fine, but the TE, and Story view and edit pages never loaded correctly (eg an empty body).
- That ministry of health record previously had no title. Which caused both the dnz set page and TE to fail (empty body of the page).
- https://digitalnz.org/stories/59a4a6b8fb002c08f3000099
- As soon as I updated the title to "Untitled" it all worked fine.