### PR TITLE
IMPROVE STORY MODERATION

### DIFF
--- a/app/controllers/supplejack_api/stories/moderations_controller.rb
+++ b/app/controllers/supplejack_api/stories/moderations_controller.rb
@@ -13,10 +13,9 @@ module SupplejackApi
       respond_to :json
       before_action :authenticate_admin!
 
-      def show
-        @user_sets = UserSet.public_sets(page: params[:page])
+      def index
+        @user_sets = UserSet.all_public_sets
         render json: @user_sets, each_serializer: StoriesModerationSerializer,
-               meta: { total: UserSet.public_sets_count },
                root: 'sets', adapter: :json
       end
     end

--- a/app/models/supplejack_api/concerns/user_set.rb
+++ b/app/models/supplejack_api/concerns/user_set.rb
@@ -99,6 +99,10 @@ module SupplejackApi::Concerns::UserSet
                  end
     end
 
+    def self.all_public_sets
+      where(privacy: 'public', :name.ne => 'Favourites')
+    end
+
     def self.public_sets(options = {})
       options.reverse_merge!(page: 1, per_page: 100)
       page = options[:page].to_i

--- a/app/serializers/supplejack_api/stories_moderation_serializer.rb
+++ b/app/serializers/supplejack_api/stories_moderation_serializer.rb
@@ -8,6 +8,6 @@
 
 module SupplejackApi
   class StoriesModerationSerializer < ActiveModel::Serializer
-    attributes :id, :name, :count, :approved, :featured, :created_at, :updated_at, :featured_at
+    attributes :id, :name, :count, :approved, :featured, :created_at, :updated_at, :featured_at, :user_id
   end
 end

--- a/app/serializers/supplejack_api/stories_moderation_serializer.rb
+++ b/app/serializers/supplejack_api/stories_moderation_serializer.rb
@@ -8,6 +8,6 @@
 
 module SupplejackApi
   class StoriesModerationSerializer < ActiveModel::Serializer
-    attributes :id, :name, :user, :count, :approved, :featured, :created_at, :updated_at, :featured_at
+    attributes :id, :name, :count, :approved, :featured, :created_at, :updated_at, :featured_at
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ SupplejackApi::Engine.routes.draw do
   devise_for :users, class_name: 'SupplejackApi::User'
 
   namespace :stories do
-    resource :moderation, only: [:show]
+    resources :moderations, only: [:index]
   end
 
   # Admin level authentication

--- a/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
@@ -21,7 +21,7 @@ module SupplejackApi
           allow(controller).to receive(:current_user) { @user }
         end
 
-        describe '#show' do
+        describe '#index' do
           let!(:user_set) { FactoryGirl.create(:user_set, name: "Dogs and cats", priority: 5) }
 
           before :each do
@@ -31,12 +31,12 @@ module SupplejackApi
           end
 
           it 'finds all public sets' do
-            expect(UserSet).to receive(:public_sets).with(page: nil) { [] }
-            get :show, format: 'json'
+            expect(UserSet).to receive(:all_public_sets) { [] }
+            get :index, format: 'json'
           end
 
           it 'renders the public sets as JSON' do
-            get :show, format: 'json'
+            get :index, format: 'json'
             sets = JSON.parse(response.body)
 
             sets['sets'].each do |set|
@@ -47,15 +47,13 @@ module SupplejackApi
               expect(set).to have_key 'created_at'
               expect(set).to have_key 'updated_at'
             end
-
-            expect(sets['meta']).to have_key 'total'
           end
         end
       end
 
       describe 'without an admin account' do
         it 'renders the appropriate message' do
-          get :show, format: 'json'
+          get :index, format: 'json'
           expect(response.body).to eq '{"errors":"Please provide a API Key"}'
         end
       end

--- a/spec/serializers/supplejack_api/stories_moderation_serializer_spec.rb
+++ b/spec/serializers/supplejack_api/stories_moderation_serializer_spec.rb
@@ -21,10 +21,6 @@ module SupplejackApi
         expect(serialized_user_set).to have_key :name
       end
 
-      it 'renders the user field' do
-        expect(serialized_user_set).to have_key :user
-      end
-
       it 'renders the count field' do
         expect(serialized_user_set).to have_key :count
       end


### PR DESCRIPTION
Acceptance Criteria
=================
- admin can search for stories
- admin can find/sort for stories that are different sizes

Background
=================
As a digitalnz.org admin I want to be able to search for and sort stories in moderation so that I can find particular stories and story types easily

- Change API endpoint to return all stories that are public without pagination to be consumed by the datatable js.
- Add user_id to serializer

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Builds Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)