### PR TITLE
clean up story items post method

### DIFF
--- a/app/services/stories_api/v3/endpoints/story_items.rb
+++ b/app/services/stories_api/v3/endpoints/story_items.rb
@@ -43,8 +43,7 @@ module StoriesApi
           validator = StoriesApi::V3::Schemas::StoryItem::BlockValidator.new.call(params[:item])
           return create_error('SchemaValidationError', errors: validator.messages(full: true)) unless validator.success?
 
-          # FIXME: record_id is being posted in params by dnz website but not showing up here.
-          story_item = story.set_items.build(@item_params.merge(record_id: @item_params[:content][:record_id]))
+          story_item = story.set_items.build(@item_params)
           story.cover_thumbnail = story_item.content[:image_url] unless story.cover_thumbnail
           story.save!
 

--- a/app/services/stories_api/v3/endpoints/story_items.rb
+++ b/app/services/stories_api/v3/endpoints/story_items.rb
@@ -43,9 +43,9 @@ module StoriesApi
           validator = StoriesApi::V3::Schemas::StoryItem::BlockValidator.new.call(params[:item])
           return create_error('SchemaValidationError', errors: validator.messages(full: true)) unless validator.success?
 
-          story_item = story.set_items.build(@item_params)
+          # FIXME: record_id is being posted in params by dnz website but not showing up here.
+          story_item = story.set_items.build(@item_params.merge(record_id: @item_params[:content][:record_id]))
           story.cover_thumbnail = story_item.content[:image_url] unless story.cover_thumbnail
-
           story.save!
 
           if position

--- a/app/services/stories_api/v3/endpoints/story_items.rb
+++ b/app/services/stories_api/v3/endpoints/story_items.rb
@@ -16,7 +16,9 @@ module StoriesApi
 
         def initialize(params)
           @params = params
+          @item_params = params[:item]&.deep_symbolize_keys
           @user = SupplejackApi::User.find_by_api_key(params[:user_key])
+
           if @user
             @story = @user.user_sets.find_by_id(params[:story_id])
             @errors = create_error('StoryNotFound', id: params[:story_id]) unless @story.present?
@@ -36,22 +38,12 @@ module StoriesApi
           return @errors if @errors
           return create_error('MandatoryParamMissing', param: :item) unless params[:item]
 
-          position = params[:item].delete(:position)
+          position = @item_params.delete(:position)
 
           validator = StoriesApi::V3::Schemas::StoryItem::BlockValidator.new.call(params[:item])
           return create_error('SchemaValidationError', errors: validator.messages(full: true)) unless validator.success?
 
-          item_params = params[:item].deep_symbolize_keys
-
-          # FIXME: This is a temporary fix
-          # Can be removed after user_sets is retired
-          if item_params[:content][:id]
-            item_params[:record_id] = item_params[:content][:id]
-            record = SupplejackApi.config.record_class.custom_find(item_params[:record_id])
-            item_params[:content][:image_url] = record.large_thumbnail_url || record.thumbnail_url if record
-          end
-
-          story_item = story.set_items.build(item_params)
+          story_item = story.set_items.build(@item_params)
           story.cover_thumbnail = story_item.content[:image_url] unless story.cover_thumbnail
 
           story.save!
@@ -66,6 +58,12 @@ module StoriesApi
 
           create_response(status: 200,
                           payload: ::StoriesApi::V3::Presenters::StoryItem.new.call(story_item))
+        end
+
+        private
+
+        def text_item?
+          @item_params[:type] == 'text'
         end
       end
     end

--- a/spec/services/stories_api/v3/endpoints/story_items_spec.rb
+++ b/spec/services/stories_api/v3/endpoints/story_items_spec.rb
@@ -289,11 +289,10 @@ module StoriesApi
               it 'updates the cover thumbnail if it dosent exist' do
                 @story.update_attribute(:cover_thumbnail, nil)
                 factory = create(:story_item, type: 'embed', sub_type: 'record',
-                             content: { id: record.record_id},
+                             content: { id: record.record_id, image_url: record.large_thumbnail_url},
                              meta: { metadata: 'Some Meta' })
 
                 item = factory.attributes.symbolize_keys
-
                 expect(@story.cover_thumbnail).to be_nil
 
                 StoryItems.new(story_id: @story.id,


### PR DESCRIPTION
This was a time box story to fix one 'fixme' in the sj stack.  Changes have been made here and on DNZ. 

DNZ website has been fixed to submit the right data, so we don’t need
to add parameters to the content hash as we were previously.  However, the record_id param is not coming through to this class, aso there is still some more work to do until we remove the params merge. 