### PR TITLE
FIX XML FACETING ON API: As a API consumer I want the XML to be valid when faceting, so that I can continue to use the XML faceting functionality

### DIFF
--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -30,7 +30,7 @@ module SupplejackApi
                      callback: params['jsonp']
             end
             format.xml do
-              options = { serializer: SearchSerializer, record_fields: available_fields }
+              options = { serializer: SearchSerializer, record_fields: available_fields, request_format: 'xml' }
               serializable_resource = ActiveModelSerializers::SerializableResource.new(@search, options)
 
               # The double as_json is required to render the inner json object as json as well as the exterior object

--- a/app/serializers/supplejack_api/search_serializer.rb
+++ b/app/serializers/supplejack_api/search_serializer.rb
@@ -29,11 +29,11 @@ module SupplejackApi
       end
     end
 
-    private
-
     def xml?
       instance_options[:request_format] == 'xml'
     end
+
+    private
 
     # This is because the structure of XML Facets and JSON facets are different.
 

--- a/app/serializers/supplejack_api/search_serializer.rb
+++ b/app/serializers/supplejack_api/search_serializer.rb
@@ -22,12 +22,32 @@ module SupplejackApi
     attribute :solr_request_params, if: -> { object.solr_request_params }
     attribute :warnings, if: -> { object.warnings.present? }
     attribute :facets do
-      facets
+      if xml?
+        xml_facets
+      else
+        json_facets
+      end
     end
 
     private
 
-    def facets
+    def xml?
+      instance_options[:request_format] == 'xml'
+    end
+
+    # This is because the structure of XML Facets and JSON facets are different.
+
+    def xml_facets
+      object.facets.each_with_object([]) do |facet, facets|
+        values = facet.rows.map do |row|
+          { name: row.value, count: row.count }
+        end
+
+        facets << { name: facet.name.to_s, values: values }
+      end
+    end
+
+    def json_facets
       object.facets.each_with_object({}) do |facet, facets|
         rows = facet.rows.each_with_object({}) do |row, hash|
           hash[row.value] = row.count

--- a/spec/serializers/supplejack_api/search_serializer_spec.rb
+++ b/spec/serializers/supplejack_api/search_serializer_spec.rb
@@ -37,15 +37,19 @@ module SupplejackApi
       expect(serialized_search).to have_key :facets
     end
 
+    it 'returns facets formatted for JSON when the request_format is JSON' do
+      expect(serialized_search[:facets]).to be_a(Hash)
+    end
+
     describe '#xml?' do
+      let(:xml_serializer) { described_class.new(search, { request_format: 'xml' }) }
+
       it 'returns true when the serializer has been initialized for XML' do
-        serializer = described_class.new(search, { request_format: 'xml'} )
-        expect(serializer.xml?).to eq true
+        expect(xml_serializer.xml?).to eq true
       end
 
-      it 'returns false when the serializer has not been initialized for XML' do
-        serializer = described_class.new(search)
-        expect(serializer.xml?).to eq false
+      it 'returns facets as an array' do
+        expect(xml_serializer.as_json[:facets]).to be_a(Array)
       end
     end
   end

--- a/spec/serializers/supplejack_api/search_serializer_spec.rb
+++ b/spec/serializers/supplejack_api/search_serializer_spec.rb
@@ -36,5 +36,17 @@ module SupplejackApi
     it 'renders the facets' do
       expect(serialized_search).to have_key :facets
     end
+
+    describe '#xml?' do
+      it 'returns true when the serializer has been initialized for XML' do
+        serializer = described_class.new(search, { request_format: 'xml'} )
+        expect(serializer.xml?).to eq true
+      end
+
+      it 'returns false when the serializer has not been initialized for XML' do
+        serializer = described_class.new(search)
+        expect(serializer.xml?).to eq false
+      end
+    end
   end
 end


### PR DESCRIPTION
Identify the previous XML response syntax (via an old branch on dnz0a)
Faceting on the API returns valid XML syntax as per previous point