### PR TITLE
REMOVE OLD TAPUHI HARVEST STRATEGY AND CODE FROM SJ

### DIFF
--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -139,15 +139,15 @@ module SupplejackApi
       describe "DELETE flush" do
         before do
           allow(Record).to receive(:flush_old_records)
-          expect(FlushOldRecordsWorker).to receive(:perform_async).with('tapuhi', 'abc123')
+          expect(FlushOldRecordsWorker).to receive(:perform_async).with('source_id', 'abc123')
         end
 
         it "calls flush_old_records" do
-          delete :flush, source_id: 'tapuhi', job_id: 'abc123', api_key: api_key
+          delete :flush, source_id: 'source_id', job_id: 'abc123', api_key: api_key
         end
 
         it "returns a 204" do
-          delete :flush, source_id: 'tapuhi', job_id: 'abc123', api_key: api_key
+          delete :flush, source_id: 'source_id', job_id: 'abc123', api_key: api_key
 
           expect(response.code).to eq '204'
         end

--- a/spec/factories/fragment.rb
+++ b/spec/factories/fragment.rb
@@ -7,7 +7,7 @@ module SupplejackApi
       title                 'A record'
       creator               ['John Kennedy']
       dnz_type              'Unknown'
-      primary_collection    ['TAPUHI']
+      primary_collection    ['PRIMARY_COLLECTION']
       thumbnail {FactoryGirl.build(:thumbnail)}
     end
   end

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -327,10 +327,10 @@ module SupplejackApi
     end
 
     describe "#update_attributes_and_embedded" do
-      before { 
+      before {
         developer = double(:developer)
         admin = double(:admin, admin: true, role: 'admin')
-        allow(RecordSchema).to receive(:roles) { { admin: admin, developer: developer } } 
+        allow(RecordSchema).to receive(:roles) { { admin: admin, developer: developer } }
       }
 
       it "updates the set attributes" do
@@ -499,7 +499,7 @@ module SupplejackApi
 
         it "should not create a new record if already linked" do
           allow(user_set).to receive(:record) { double(:record).as_null_object }
-          expect(SupplejackApi::Record).to_not receive(:new) 
+          expect(SupplejackApi::Record).to_not receive(:new)
           user_set.update_record
         end
 
@@ -527,7 +527,7 @@ module SupplejackApi
         @record = FactoryGirl.build(:record)
         allow(user_set).to receive(:record) { @record }
       end
-        
+
       it "should set record status to deleted" do
         user_set.delete_record
         expect(user_set.record.status).to eq "deleted"
@@ -634,7 +634,7 @@ module SupplejackApi
     describe "#items_with_records" do
       it "returns an array of set items with record information" do
         record = FactoryGirl.create(:record, record_id: 5)
-        fragment = record.fragments.create( title: "Dog", description: "Ugly dog", display_content_partner: "ATL", display_collection: "Tapuhi", large_thumbnail_attributes: {url: "goo.gle/large"}, thumbnail_attributes: {url: "goo.gle/small"})
+        fragment = record.fragments.create( title: "Dog", description: "Ugly dog", display_content_partner: "ATL", display_collection: "Display collection", large_thumbnail_attributes: {url: "goo.gle/large"}, thumbnail_attributes: {url: "goo.gle/small"})
         user_set.set_items.build(record_id: 5, position: 1)
         expect(user_set.items_with_records.first.record).to eq record
       end

--- a/spec/workers/supplejack_api/source_index_worker_spec.rb
+++ b/spec/workers/supplejack_api/source_index_worker_spec.rb
@@ -1,8 +1,8 @@
-# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government, 
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
 # and is licensed under the GNU General Public License, version 3.
-# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and 
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 
 require "spec_helper"
@@ -14,33 +14,33 @@ module SupplejackApi
 
       before do
         records.each do |r|
-          r.primary_fragment.source_id = 'tapuhi'
+          r.primary_fragment.source_id = 'source_id'
           r.save
         end
 
-        allow(Record).to receive(:where).with(hash_including(:'fragments.source_id' => 'tapuhi')).and_call_original
+        allow(Record).to receive(:where).with(hash_including(:'fragments.source_id' => 'source_id')).and_call_original
       end
 
       it "finds all active records and indexes them" do
-        expect(Record).to receive(:where).with(:'fragments.source_id' => 'tapuhi').and_call_original
+        expect(Record).to receive(:where).with(:'fragments.source_id' => 'source_id').and_call_original
         expect(Sunspot).to receive(:index).with(records)
 
-        IndexSourceWorker.new.perform('tapuhi')
+        IndexSourceWorker.new.perform('source_id')
       end
 
       it "finds all deleted records and removes them from solr" do
         records.each { |r| r.update_attribute(:status, 'deleted') }
 
-        expect(Record).to receive(:where).with(:'fragments.source_id' => 'tapuhi').and_call_original
+        expect(Record).to receive(:where).with(:'fragments.source_id' => 'source_id').and_call_original
         expect(Sunspot).to receive(:remove).with(records)
-        IndexSourceWorker.new.perform('tapuhi')
+        IndexSourceWorker.new.perform('source_id')
       end
 
       it "finds records updated more recently than the date given" do
         date = Time.now
         allow(Time).to receive(:parse) { date }
-        expect(Record).to receive(:where).with(:'fragments.source_id' => 'tapuhi', :updated_at.gt => date)
-        IndexSourceWorker.new.perform('tapuhi', date.to_s)
+        expect(Record).to receive(:where).with(:'fragments.source_id' => 'source_id', :updated_at.gt => date)
+        IndexSourceWorker.new.perform('source_id', date.to_s)
       end
     end
 


### PR DESCRIPTION
Check in with PO after initial investigation to identify code
SJ codebase does not contain the Tapuhi harvest strategy or any of its relevant code/DSL.
