### PR TITLE
ADD HA PROXY STATUS ROUTE TESTS

### DIFF
--- a/app/controllers/supplejack_api/status_controller.rb
+++ b/app/controllers/supplejack_api/status_controller.rb
@@ -21,6 +21,7 @@ module SupplejackApi
     TIMEOUT = 10.seconds
 
     def show
+      expires_now
       both_ok = Timeout.timeout(TIMEOUT) do
         solr_ok = solr_up?
         mongo_ok = mongod_up?

--- a/spec/controllers/supplejack_api/status_controller_spec.rb
+++ b/spec/controllers/supplejack_api/status_controller_spec.rb
@@ -26,6 +26,14 @@ module SupplejackApi
         expect(response.status).to eq 200
       end
 
+      it 'returns the correct cache headers' do
+        allow(controller).to receive(:solr_up?).and_return(true)
+        allow(controller).to receive(:mongod_up?).and_return(true)
+        get :show
+
+        expect(response.headers['Cache-Control']).to eq 'no-cache'
+      end
+
       it "returns a '500' HTTP response if Solr is down" do
         allow(controller).to receive(:solr_up?).and_return(false)
         allow(controller).to receive(:mongod_up?).and_return(true)


### PR DESCRIPTION
*Acceptance Criteria*
- Tests are in place to effectively check the HA proxy status route on the api, thumbnailer and DNZ
- Check ha proxy for other status routes that need to have tests. (no cache)