### PR TITLE
Fix Installation script bugs

### DIFF
--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -16,7 +16,7 @@ module SupplejackApi
     respond_to :json, :xml
 
     def index
-      @search = SupplejackApi::RecordSearch.new(params)
+      @search = SupplejackApi::RecordSearch.new(all_params)
       @search.request_url = request.original_url
       @search.scope = current_user
 
@@ -102,6 +102,10 @@ module SupplejackApi
       # params which would otherwise not be nested).  It's easiest to convert them all to an unsafe
       # hash and work with them that way.
       params[:search]&.to_unsafe_h
+    end
+
+    def all_params
+      params.to_unsafe_h
     end
   end
 end

--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -75,7 +75,7 @@ module SupplejackApi
         inject_into_file('Gemfile', after: /^gem.*supplejack_api.*/) do
           string = [""]
           string << "gem 'sunspot_rails', '~> 2.2.0'"
-          string << "gem 'active_model_serializers', git: 'https://github.com/boost/active_model_serializers.git' "
+          string << "gem 'active_model_serializers', '~> 0.10.7'"
           string << "gem 'mongoid_auto_increment'"
 
           string << "gem 'whenever', '~> 0.10.0'"

--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -59,11 +59,6 @@ module SupplejackApi
         gsub_file('config/environments/production.rb', 'Dummy::Application', Rails.application.class.to_s)
       end
 
-      def solr_config_files
-        puts "\nInstalling Solr config files into solr/"
-        directory 'solr'
-      end
-
       def mount_engine
         puts "\nMounting SupplejackApi::Engine at / in config/routes.rb"
 

--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -75,10 +75,10 @@ module SupplejackApi
         inject_into_file('Gemfile', after: /^gem.*supplejack_api.*/) do
           string = [""]
           string << "gem 'sunspot_rails', '~> 2.2.0'"
-          string << "gem 'active_model_serializers', git: 'https://github.com/boost/active_model_serializers.git'"
-          string << "gem 'mongoid_auto_increment"
+          string << "gem 'active_model_serializers', git: 'https://github.com/boost/active_model_serializers.git' "
+          string << "gem 'mongoid_auto_increment'"
 
-          string << "gem 'whenever', '~> 0.9'"
+          string << "gem 'whenever', '~> 0.10.0'"
 
           string.join("\n")
         end

--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -81,10 +81,9 @@ module SupplejackApi
       end
 
       def create_schema
-        puts "\nCreating Schemas in app/supplejack_api/"
-
+        puts "\nCreating Default Record Schemas in app/supplejack_api/"
         empty_directory 'app/supplejack_api'
-        copy_file 'app/supplejack_api/record_schema.rb'
+        copy_file 'app/supplejack_api/record_schema.txt','app/supplejack_api/record_schema.rb'
         copy_file 'app/supplejack_api/concept_schema.rb'
       end
 

--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -45,6 +45,7 @@ module SupplejackApi
         copy_file 'config/initializers/simple_form_foundation.rb'
         copy_file 'config/initializers/state_machine.rb'
         copy_file 'config/initializers/sunspot.rb'
+        copy_file 'config/initializers/supplejack_api.rb'
         copy_file 'config/initializers/mongoid.rb'
         copy_file 'config/initializers/interaction_updaters.rb'
         copy_file 'config/initializers/force_eagerload.rb'
@@ -121,6 +122,10 @@ module SupplejackApi
 
           puts string.join("\n")
         end
+      end
+
+      def finished
+        puts 'supplejack_api generator install is complete'
       end
     end
   end

--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -90,9 +90,9 @@ module SupplejackApi
 
       def add_assets
         puts "\nAdding assets "
-        insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highcharts\n", :after => "jquery_ujs\n"
-        insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highcharts-more\n", :after => "jquery_ujs\n"
-        insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highstock\n", :after => "jquery_ujs\n"
+        insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highcharts\n", :after => "rails-ujs\n"
+        insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highcharts-more\n", :after => "rails-ujs\n"
+        insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highstock\n", :after => "rails-ujs\n"
         insert_into_file "app/assets/stylesheets/application.css", "\n *= require supplejack_api/application", :after => "require_self"
       end
 

--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -93,6 +93,7 @@ module SupplejackApi
       end
 
       def add_assets
+        puts "\nAdding assets "
         insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highcharts\n", :after => "jquery_ujs\n"
         insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highcharts-more\n", :after => "jquery_ujs\n"
         insert_into_file "app/assets/javascripts/application.js", "//= require highcharts/highstock\n", :after => "jquery_ujs\n"

--- a/spec/dummy/app/supplejack_api/record_schema.txt
+++ b/spec/dummy/app/supplejack_api/record_schema.txt
@@ -1,66 +1,43 @@
 # The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
 # and is licensed under the GNU General Public License, version 3.
 # One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
-#
 # Supplejack was created by DigitalNZ at the National Library of NZ and
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 
 class RecordSchema
   include SupplejackApi::SupplejackSchema
-
   # Namespaces
-  namespace :dc,        url: 'http://purl.org/dc/elements/1.1/'
-  namespace :sj,        url: ''
-
+  namespace :dc, url: 'http://purl.org/dc/elements/1.1/'
   # Fields
-  string    :record_id,                   store: false,                                           namespace: :sj
-  string    :concept_ids,                                                                         namespace: :sj
-  string    :title,                       search_boost: 10,     search_as: [:filter, :fulltext],  namespace: :dc
-  string    :description,                 search_boost: 2,      search_as: [:filter, :fulltext],  namespace: :dc
-        
-  string    :display_content_partner,                           search_as: [:filter, :fulltext],  namespace: :sj
-  string    :display_collection,                                search_as: [:filter, :fulltext],  namespace: :sj
-  string    :source_url,                                                                          namespace: :sj
-  string    :thumbnail_url
-  string    :subject,                     multi_value: true,                                      namespace: :dc
-  string    :display_date,                                                                        namespace: :sj
-  string    :creator,                     multi_value: true,                                      namespace: :dc
-  string    :category,                    multi_value: true,    search_as: [:filter],             namespace: :sj
+  string    :record_id, store: false
+  string    :internal_identifier
+  string    :title,  search_boost: 10,  search_as: [:filter, :fulltext], namespace: :dc
+  string    :description,  search_boost: 2,  search_as: [:filter, :fulltext],  namespace:   :dc
+  string    :display_collection,  search_as: [:filter, :fulltext],  namespace: :sj
+  string    :display_content_partner, multi_value: true,  namespace: :dc
+  string    :category,  multi_value: true,  search_as: [:filter]
+  string    :source_url
+  string    :landing_url
+  string    :status
+  datetime  :created_at, date_format: '%y/%d/%m'
 
   # Groups
   group :default do
     fields [
-      :title,
-      :description
-    ]
-  end
-
-  group :all do
-    includes [:default]
-    fields [
       :record_id,
-      :concept_ids,
-      :subject,
+      :internal_identifier,
+      :title,
+      :description,
+      :category,
       :display_content_partner,
       :display_collection,
       :source_url,
-      :thumbnail_url,
-      :display_date,
-      :creator,
-      :category
+      :landing_url
     ]
   end
 
-  group :core do
-    fields [:record_id]
-  end
-
-   # Roles
-  role :developer do
-    default true
-  end
-  role :admin
-
-  mongo_index :source_url,         fields: [{source_url: 1}]
-
+  # Roles
+  role :developer, default: true
+  role :admin, admin: true
+  role :harvester, harvester: true
 end

--- a/spec/dummy/config/initializers/supplejack_api.rb
+++ b/spec/dummy/config/initializers/supplejack_api.rb
@@ -1,4 +1,4 @@
 SupplejackApi.setup do |config|
-  config.record_class = ::Record
-  config.preview_record_class = ::PreviewRecord
+  config.record_class = SupplejackApi::Record
+  config.preview_record_class = SupplejackApi::PreviewRecord
 end

--- a/spec/dummy/config/initializers/supplejack_api.rb
+++ b/spec/dummy/config/initializers/supplejack_api.rb
@@ -1,3 +1,4 @@
 SupplejackApi.setup do |config|
-  # Config avaialble at engine.rb
+  config.record_class = ::Record
+  config.preview_record_class = ::PreviewRecord
 end


### PR DESCRIPTION
Installation command works with rails 5 version of the sj api gem
template is updated and locked to the rails 5 version/release for the SJ api gem
Respond to open source user here and close the issue once they confirm it's working form them
https://github.com/DigitalNZ/supplejack_installation/issues/3