### PR TITLE
API USER MANAGEMENT ENDPOINTS SETUP:

### DIFF
--- a/app/controllers/supplejack_api/harvester/users_controller.rb
+++ b/app/controllers/supplejack_api/harvester/users_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This controller is used by the Manager to retrieve the user statistics.
+
+module SupplejackApi
+  module Harvester
+    class UsersController < ApplicationController
+      respond_to :json
+      before_action :authenticate_harvester!
+
+      def index
+        @users = User.sortable(
+          order: params[:order] || :daily_requests_desc, page: params[:page]
+        )
+
+        render json: @users, each_serializer: UserSerializer, root: 'users', adapter: :json
+      end
+    end
+  end
+end

--- a/app/controllers/supplejack_api/harvester/users_controller.rb
+++ b/app/controllers/supplejack_api/harvester/users_controller.rb
@@ -9,11 +9,22 @@ module SupplejackApi
       before_action :authenticate_harvester!
 
       def index
-        @users = User.sortable(
+        users = User.sortable(
           order: params[:order] || :daily_requests_desc, page: params[:page]
         )
 
-        render json: @users, each_serializer: UserSerializer, root: 'users', adapter: :json
+        render json: users, each_serializer: UserSerializer, root: 'users', adapter: :json
+      end
+
+      def update
+        user = User.find(params[:id])
+        user.update_attributes!(user_params)
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:max_requests)
       end
     end
   end

--- a/app/controllers/supplejack_api/harvester/users_controller.rb
+++ b/app/controllers/supplejack_api/harvester/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# This controller is used by the Manager to retrieve the user statistics.
+# This controller is used by the Manager to retrieve information for the admin content.
 
 module SupplejackApi
   module Harvester

--- a/app/serializers/supplejack_api/harvester/user_serializer.rb
+++ b/app/serializers/supplejack_api/harvester/user_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Harvester
+    class UserSerializer < ActiveModel::Serializer
+      attributes :id, :name, :username, :email, :api_key, :role,
+                 :max_requests, :monthly_requests, :authentication_token, :daily_requests
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ SupplejackApi::Engine.routes.draw do
     end
     resources :concepts, only: [:create, :update]
     resources :fragments, only: [:destroy]
+    resources :users
 
     # Partners
     resources :partners, except: [:destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ SupplejackApi::Engine.routes.draw do
     end
     resources :concepts, only: [:create, :update]
     resources :fragments, only: [:destroy]
-    resources :users
+    resources :users, only: [:index, :update]
 
     # Partners
     resources :partners, except: [:destroy] do

--- a/spec/controllers/supplejack_api/harvester/users_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/users_controller_spec.rb
@@ -30,48 +30,5 @@ RSpec.describe SupplejackApi::Harvester::UsersController do
       get :index, format: :json, params: { api_key: developer_api_key }
       expect(response.status).to eq 403
     end
-
-    context 'attributes' do
-      before do
-        get :index, params: { api_key: harvester_api_key }, format: :json
-        @user = JSON.parse(response.body)['users'].first
-      end
-
-      it 'renders the :id' do
-        expect(@user).to have_key 'id'
-      end
-
-      it 'renders the :username' do
-        expect(@user).to have_key 'username'
-      end
-
-      it 'renders the :name' do
-        expect(@user).to have_key 'name'
-      end
-
-      it 'renders the :authentication_token' do
-        expect(@user).to have_key 'authentication_token'
-      end
-
-      it 'renders the :email' do
-        expect(@user).to have_key 'email'
-      end
-
-      it 'renders the :role' do
-        expect(@user).to have_key 'role'
-      end
-
-      it 'renders the :daily_requests' do
-        expect(@user).to have_key 'daily_requests'
-      end
-
-      it 'renders the :monthly_requests' do
-        expect(@user).to have_key 'monthly_requests'
-      end
-
-      it 'renders the :max_requests' do
-        expect(@user).to have_key 'max_requests'
-      end
-    end
   end
 end

--- a/spec/controllers/supplejack_api/harvester/users_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/users_controller_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SupplejackApi::Harvester::UsersController do
+  routes { SupplejackApi::Engine.routes }
+
+  let(:harvester_api_key) { create(:user, role: 'harvester').api_key }
+  let(:developer_api_key) { create(:user, role: 'developer').api_key }
+  let!(:users)  { create_list(:user, 5) }
+
+  describe '#index' do
+    it 'renders a succesful status code' do
+      get :index, params: { api_key: harvester_api_key }, format: :json
+      expect(response.status).to eq 200
+    end
+
+    it 'renders the @users as JSON' do
+      get :index, params: { api_key: harvester_api_key }, format: :json
+      u = SupplejackApi::User.sortable(order: :daily_requests_desc)
+      expect(JSON.parse(response.body)['users']).to eq u.map { |x| SupplejackApi::UserSerializer.new(x).as_json.as_json }
+    end
+
+    it 'requires an API key' do
+      get :index, format: :json
+      expect(response.status).to eq 403
+    end
+
+    it 'requires an API key with harvester privilages' do
+      get :index, format: :json, params: { api_key: developer_api_key }
+      expect(response.status).to eq 403
+    end
+  end
+end

--- a/spec/controllers/supplejack_api/harvester/users_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/users_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SupplejackApi::Harvester::UsersController do
     it 'renders the @users as JSON' do
       get :index, params: { api_key: harvester_api_key }, format: :json
       u = SupplejackApi::User.sortable(order: :daily_requests_desc)
-      expect(JSON.parse(response.body)['users']).to eq u.map { |x| SupplejackApi::UserSerializer.new(x).as_json.as_json }
+      expect(JSON.parse(response.body)['users']).to eq u.map { |x| SupplejackApi::Harvester::UserSerializer.new(x).as_json.as_json }
     end
 
     it 'requires an API key' do
@@ -29,6 +29,49 @@ RSpec.describe SupplejackApi::Harvester::UsersController do
     it 'requires an API key with harvester privilages' do
       get :index, format: :json, params: { api_key: developer_api_key }
       expect(response.status).to eq 403
+    end
+
+    context 'attributes' do
+      before do
+        get :index, params: { api_key: harvester_api_key }, format: :json
+        @user = JSON.parse(response.body)['users'].first
+      end
+
+      it 'renders the :id' do
+        expect(@user).to have_key 'id'
+      end
+
+      it 'renders the :username' do
+        expect(@user).to have_key 'username'
+      end
+
+      it 'renders the :name' do
+        expect(@user).to have_key 'name'
+      end
+
+      it 'renders the :authentication_token' do
+        expect(@user).to have_key 'authentication_token'
+      end
+
+      it 'renders the :email' do
+        expect(@user).to have_key 'email'
+      end
+
+      it 'renders the :role' do
+        expect(@user).to have_key 'role'
+      end
+
+      it 'renders the :daily_requests' do
+        expect(@user).to have_key 'daily_requests'
+      end
+
+      it 'renders the :monthly_requests' do
+        expect(@user).to have_key 'monthly_requests'
+      end
+
+      it 'renders the :max_requests' do
+        expect(@user).to have_key 'max_requests'
+      end
     end
   end
 end

--- a/spec/controllers/supplejack_api/harvester/users_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/users_controller_spec.rb
@@ -31,4 +31,19 @@ RSpec.describe SupplejackApi::Harvester::UsersController do
       expect(response.status).to eq 403
     end
   end
+
+  describe '#update' do
+    let(:user) { users.first }
+
+    it 'can update the max request limit' do
+      patch :update, params: { id: user, api_key: harvester_api_key, user: { max_requests: 10 } }
+      user.reload
+      expect(user.max_requests).to eq 10
+    end
+
+    it 'requires an API key' do
+      patch :update, params: { id: user, api_key: developer_api_key, user: { max_requests: 10 } }
+      expect(response.status).to eq 403
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
-# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government, 
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
 # and is licensed under the GNU General Public License, version 3.
-# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and 
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 
 module SupplejackApi
@@ -12,6 +12,9 @@ module SupplejackApi
       daily_requests        0
       max_requests          1000
       role                  'developer'
+      name                  { Faker::Name.name }
+      username              { Faker::Name.first_name.downcase }
+      email                 { Faker::Internet.email }
 
       factory :admin_user do
         role                'admin'

--- a/spec/serializers/supplejack_api/harvester/user_serializer_spec.rb
+++ b/spec/serializers/supplejack_api/harvester/user_serializer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SupplejackApi::Harvester::UserSerializer do
+  let(:user) { create(:user) }
+  let(:serializer) { described_class.new(user).as_json }
+
+  describe '#attributes' do
+    it 'renders the :id' do
+      expect(serializer).to have_key :id
+    end
+
+    it 'renders the :username' do
+      expect(serializer).to have_key :username
+    end
+
+    it 'renders the :name' do
+      expect(serializer).to have_key :name
+    end
+
+    it 'renders the :authentication_token' do
+      expect(serializer).to have_key :authentication_token
+    end
+
+    it 'renders the :email' do
+      expect(serializer).to have_key :email
+    end
+
+    it 'renders the :role' do
+      expect(serializer).to have_key :role
+    end
+
+    it 'renders the :daily_requests' do
+      expect(serializer).to have_key :daily_requests
+    end
+
+    it 'renders the :monthly_requests' do
+      expect(serializer).to have_key :monthly_requests
+    end
+
+    it 'renders the :max_requests' do
+      expect(serializer).to have_key :max_requests
+    end
+  end
+end


### PR DESCRIPTION
Endpoints in place to replicate all current API admin features on https://api.digitalnz.org/admin/users/sign_in for example:
endpoint for getting all admin users
post api endpoint for changing request limit