### PR TITLE
LOG RECORD DATA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ bundler_args: --without production
 sudo: false
 before_script:
   - cp spec/dummy/config/mongoid.travis.yml spec/dummy/config/mongoid.yml
+  - echo 'Pacific/Auckland' | sudo tee /etc/timezone
+  - sudo dpkg-reconfigure --frontend noninteractive tzdata
 script:
   - bundle exec rspec
   - bundle exec rubocop

--- a/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
@@ -30,7 +30,7 @@ module SupplejackApi
         end
 
         def log_source_clickthrough
-          return unless @record
+          return unless @record && log_request_for_metrics?
 
           SupplejackApi::InteractionModels::SourceClickthrough.create(facet: @record.display_collection)
 

--- a/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
@@ -22,7 +22,7 @@ module SupplejackApi
         end
 
         def log_record_view
-          return unless log_request_for_metrics?
+          return unless @record && log_request_for_metrics?
 
           SupplejackApi::InteractionModels::Record.create_find(@record)
 

--- a/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
@@ -14,6 +14,10 @@ module SupplejackApi
           return unless @search.valid? && log_request_for_metrics?
 
           SupplejackApi::InteractionModels::Record.create_search(@search)
+
+          @search.records.each do |record|
+            RecordMetric.find_or_create_by(record_id: record.record_id, date: Time.zone.today).increment(:appeared_in_searches)
+          end
         end
 
         def log_record_view

--- a/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
@@ -9,6 +9,7 @@ module SupplejackApi
       included do
         after_action :log_search, only: :index
         after_action :log_record_view, only: :show
+        after_action :log_source_clickthrough, only: :source
 
         def log_search
           return unless @search.valid? && log_request_for_metrics?
@@ -26,6 +27,14 @@ module SupplejackApi
           SupplejackApi::InteractionModels::Record.create_find(@record)
 
           SupplejackApi::RecordMetric.spawn(@record.record_id, :page_views)
+        end
+
+        def log_source_clickthrough
+          return unless @record
+
+          SupplejackApi::InteractionModels::SourceClickthrough.create(facet: @record.display_collection)
+
+          SupplejackApi::RecordMetric.spawn(@record.record_id, :source_clickthroughs)
         end
       end
     end

--- a/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
@@ -16,7 +16,7 @@ module SupplejackApi
           SupplejackApi::InteractionModels::Record.create_search(@search)
 
           @search.records.each do |record|
-            RecordMetric.find_or_create_by(record_id: record.record_id, date: Time.zone.today).increment(:appeared_in_searches)
+            SupplejackApi::RecordMetric.spawn(record.record_id, :appeared_in_searches)
           end
         end
 
@@ -24,6 +24,8 @@ module SupplejackApi
           return unless log_request_for_metrics?
 
           SupplejackApi::InteractionModels::Record.create_find(@record)
+
+          SupplejackApi::RecordMetric.spawn(@record.record_id, :page_views)
         end
       end
     end

--- a/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
@@ -17,7 +17,7 @@ module SupplejackApi
           SupplejackApi::InteractionModels::Record.create_search(@search)
 
           @search.records.each do |record|
-            SupplejackApi::RecordMetric.spawn(record.record_id, :appeared_in_searches)
+            SupplejackApi::RecordMetric.spawn(record.record_id, :appeared_in_searches, record.content_partner)
           end
         end
 
@@ -26,7 +26,7 @@ module SupplejackApi
 
           SupplejackApi::InteractionModels::Record.create_find(@record)
 
-          SupplejackApi::RecordMetric.spawn(@record.record_id, :page_views)
+          SupplejackApi::RecordMetric.spawn(@record.record_id, :page_views, @record.content_partner)
         end
 
         def log_source_clickthrough
@@ -34,7 +34,7 @@ module SupplejackApi
 
           SupplejackApi::InteractionModels::SourceClickthrough.create(facet: @record.display_collection)
 
-          SupplejackApi::RecordMetric.spawn(@record.record_id, :source_clickthroughs)
+          SupplejackApi::RecordMetric.spawn(@record.record_id, :source_clickthroughs, @record.content_partner)
         end
       end
     end

--- a/app/controllers/supplejack_api/concerns/stories.rb
+++ b/app/controllers/supplejack_api/concerns/stories.rb
@@ -14,13 +14,13 @@ module SupplejackApi
         def render_response(endpoint)
           api = StoriesApi::V3::Api.new(params.dup, endpoint, request.method.downcase.to_sym)
 
-          api_response = api.errors ? api.errors : api.call
+          @api_response = api.errors ? api.errors : api.call
 
-          handle_errors(api_response)
+          handle_errors(@api_response)
           return if performed?
 
           # don't double render if we've already rendered an exception
-          render json: api_response[:payload].to_json(include_root: false), status: api_response[:status]
+          render json: @api_response[:payload].to_json(include_root: false), status: @api_response[:status]
         end
 
         # Renders error response for the controller action

--- a/app/controllers/supplejack_api/concerns/stories_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/stories_controller_metrics.rb
@@ -2,13 +2,12 @@
 
 module SupplejackApi
   module Concerns
-    module StoriesMetrics
+    module StoriesControllerMetrics
       extend ActiveSupport::Concern
       include IgnoreMetrics
 
       included do
         after_action :create_story_record_views, only: :show
-        after_action :create_story_interaction, only: :create
 
         def create_story_record_views
           return unless @api_response[:payload] && log_request_for_metrics?
@@ -16,14 +15,6 @@ module SupplejackApi
           @api_response[:payload][:contents].each do |record|
             SupplejackApi::RecordMetric.spawn(record[:record_id], :user_story_views, record[:content][:content_partner])
           end
-        end
-
-        def create_story_interaction
-          return unless @api_response[:payload] && log_request_for_metrics?
-
-          record = @api_response[:payload]
-
-          SupplejackApi::RecordMetric.spawn(record[:record_id], :added_to_user_stories, record[:content][:content_partner])
         end
       end
     end

--- a/app/controllers/supplejack_api/concerns/stories_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/stories_metrics.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module StoriesMetrics
+      extend ActiveSupport::Concern
+      include IgnoreMetrics
+
+      included do
+        after_action :create_story_record_views, only: :show
+        after_action :create_story_interaction, only: :create
+
+        def create_story_record_views
+          return unless @api_response[:payload] && log_request_for_metrics?
+
+          @api_response[:payload][:contents].each do |record|
+            SupplejackApi::RecordMetric.spawn(record[:record_id], :user_story_views, record[:content][:content_partner])
+          end
+        end
+
+        def create_story_interaction
+          return unless @api_response[:payload] && log_request_for_metrics?
+
+          record = @api_response[:payload]
+
+          SupplejackApi::RecordMetric.spawn(record[:record_id], :added_to_user_stories, record[:content][:content_partner])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
@@ -14,7 +14,9 @@ module SupplejackApi
 
           record = @api_response[:payload]
 
-          SupplejackApi::RecordMetric.spawn(record[:record_id], :added_to_user_stories, record[:content][:content_partner])
+          SupplejackApi::RecordMetric.spawn(record[:record_id],
+                                            :added_to_user_stories,
+                                            record[:content][:content_partner])
         end
       end
     end

--- a/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module StoryItemsControllerMetrics
+      extend ActiveSupport::Concern
+      include IgnoreMetrics
+
+      included do
+        after_action :create_story_item_interaction, only: :create
+
+        def create_story_item_interaction
+          return unless @api_response[:payload] && log_request_for_metrics?
+
+          record = @api_response[:payload]
+
+          SupplejackApi::RecordMetric.spawn(record[:record_id], :added_to_user_stories, record[:content][:content_partner])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
@@ -14,6 +14,8 @@ module SupplejackApi
 
           record = @api_response[:payload]
 
+          next if record[:record_id].blank?
+
           SupplejackApi::RecordMetric.spawn(record[:record_id],
                                             :added_to_user_stories,
                                             record[:content][:content_partner])

--- a/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
@@ -14,7 +14,7 @@ module SupplejackApi
 
           record = @api_response[:payload]
 
-          next if record[:record_id].blank?
+          return if record[:record_id].blank?
 
           SupplejackApi::RecordMetric.spawn(record[:record_id],
                                             :added_to_user_stories,

--- a/app/controllers/supplejack_api/concerns/user_sets_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/user_sets_controller_metrics.rb
@@ -14,6 +14,10 @@ module SupplejackApi
           return unless @user_set && log_request_for_metrics?
 
           SupplejackApi::InteractionModels::Record.create_user_set(@user_set)
+
+          @user_set.set_items.each do |record|
+            SupplejackApi::RecordMetric.spawn(record.record_id, :user_set_views)
+          end
         end
 
         def create_set_interaction
@@ -22,6 +26,10 @@ module SupplejackApi
 
           record = SupplejackApi.config.record_class.custom_find(@user_set.set_items.first.record_id)
           SupplejackApi::InteractionModels::Set.create(interaction_type: :creation, facet: record.display_collection)
+
+          @user_set.set_items.each do |record|
+            SupplejackApi::RecordMetric.spawn(record.record_id, :added_to_user_sets)
+          end
         end
       end
     end

--- a/app/controllers/supplejack_api/concerns/user_sets_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/user_sets_controller_metrics.rb
@@ -15,8 +15,10 @@ module SupplejackApi
 
           SupplejackApi::InteractionModels::Record.create_user_set(@user_set)
 
-          @user_set.set_items.each do |record|
-            SupplejackApi::RecordMetric.spawn(record.record_id, :user_set_views)
+          @user_set.set_items.each do |item|
+            next if item.record_id.nil?
+            record = SupplejackApi.config.record_class.custom_find(item.record_id)
+            SupplejackApi::RecordMetric.spawn(record.record_id, :user_set_views, record.content_partner)
           end
         end
 
@@ -27,8 +29,10 @@ module SupplejackApi
           record = SupplejackApi.config.record_class.custom_find(@user_set.set_items.first.record_id)
           SupplejackApi::InteractionModels::Set.create(interaction_type: :creation, facet: record.display_collection)
 
-          @user_set.set_items.each do |set_item|
-            SupplejackApi::RecordMetric.spawn(set_item.record_id, :added_to_user_sets)
+          @user_set.set_items.each do |item|
+            next if item.record_id.nil?
+            record = SupplejackApi.config.record_class.custom_find(item.record_id)
+            SupplejackApi::RecordMetric.spawn(record.record_id, :added_to_user_sets, record.content_partner)
           end
         end
       end

--- a/app/controllers/supplejack_api/concerns/user_sets_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/user_sets_controller_metrics.rb
@@ -27,8 +27,8 @@ module SupplejackApi
           record = SupplejackApi.config.record_class.custom_find(@user_set.set_items.first.record_id)
           SupplejackApi::InteractionModels::Set.create(interaction_type: :creation, facet: record.display_collection)
 
-          @user_set.set_items.each do |record|
-            SupplejackApi::RecordMetric.spawn(record.record_id, :added_to_user_sets)
+          @user_set.set_items.each do |set_item|
+            SupplejackApi::RecordMetric.spawn(set_item.record_id, :added_to_user_sets)
           end
         end
       end

--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -3,7 +3,7 @@
 module SupplejackApi
   class StoriesController < ApplicationController
     include Concerns::Stories
-    include Concerns::StoriesMetrics
+    include Concerns::StoriesControllerMetrics
 
     before_action :authenticate_admin!, only: [:admin_index]
     before_action :user_key_check!, except: %i[admin_index show]

--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -3,6 +3,7 @@
 module SupplejackApi
   class StoriesController < ApplicationController
     include Concerns::Stories
+    include Concerns::StoriesMetrics
 
     before_action :authenticate_admin!, only: [:admin_index]
     before_action :user_key_check!, except: %i[admin_index show]

--- a/app/controllers/supplejack_api/story_items_controller.rb
+++ b/app/controllers/supplejack_api/story_items_controller.rb
@@ -3,6 +3,7 @@
 module SupplejackApi
   class StoryItemsController < ApplicationController
     include Concerns::Stories
+    include Concerns::StoriesMetrics
 
     before_action :user_key_check!, except: %i[create update destroy]
 

--- a/app/controllers/supplejack_api/story_items_controller.rb
+++ b/app/controllers/supplejack_api/story_items_controller.rb
@@ -3,7 +3,7 @@
 module SupplejackApi
   class StoryItemsController < ApplicationController
     include Concerns::Stories
-    include Concerns::StoriesMetrics
+    include Concerns::StoryItemsControllerMetrics
 
     before_action :user_key_check!, except: %i[create update destroy]
 

--- a/app/models/supplejack_api/interaction_models/source_clickthrough.rb
+++ b/app/models/supplejack_api/interaction_models/source_clickthrough.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module InteractionModels
+    class SourceClickthrough
+      include Mongoid::Document
+      include Mongoid::Timestamps
+
+      field :facet, type: String
+    end
+  end
+end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,14 +5,16 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
-    field :date,                 type: Date, default: Time.zone.today
-    field :record_id,            type: Integer
-    field :page_views,           type: Integer, default: 0
-    field :user_set_views,       type: Integer, default: 0
-    field :content_partner,      type: Array
-    field :added_to_user_sets,   type: Integer, default: 0
-    field :source_clickthroughs, type: Integer, default: 0
-    field :appeared_in_searches, type: Integer, default: 0
+    field :date,                  type: Date, default: Time.zone.today
+    field :record_id,             type: Integer
+    field :page_views,            type: Integer, default: 0
+    field :user_set_views,        type: Integer, default: 0
+    field :content_partner,       type: Array
+    field :user_story_views,      type: Integer, default: 0
+    field :added_to_user_sets,    type: Integer, default: 0
+    field :source_clickthroughs,  type: Integer, default: 0
+    field :appeared_in_searches,  type: Integer, default: 0
+    field :added_to_user_stories, type: Integer, default: 0
 
     validates :record_id, presence: true
     validates :record_id, uniqueness: { scope: :date }

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,6 +5,8 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
+    # TODO: make a flag in the supplejack initializer that this functionality can be turned on, default: false.
+
     field :date,                 type: Date, default: Time.zone.today
     field :record_id,            type: Integer
     field :page_views,           type: Integer, default: 0
@@ -15,5 +17,11 @@ module SupplejackApi
 
     validates :record_id, presence: true
     validates :record_id, uniqueness: { scope: :date }
+
+    class << self
+      def spawn(record_id, metric, date = Time.zone.today)
+        RecordMetric.find_or_create_by(record_id: record_id, date: date).inc("#{metric}": 1)
+      end
+    end
   end
 end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,7 +5,7 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
-    field :date,                  type: Date, default: Time.zone.today
+    field :date,                  type: Date,    default: Time.zone.today
     field :record_id,             type: Integer
     field :page_views,            type: Integer, default: 0
     field :user_set_views,        type: Integer, default: 0
@@ -18,6 +18,8 @@ module SupplejackApi
 
     validates :record_id, presence: true
     validates :record_id, uniqueness: { scope: :date }
+
+    index({ date: 1, content_partner: 1, record_id: 1 }, background: true)
 
     def self.spawn(record_id, metric, content_partner, date = Time.zone.today)
       return unless SupplejackApi.config.log_metrics == true

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,8 +5,6 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
-    # TODO: make a flag in the supplejack initializer that this functionality can be turned on, default: false.
-
     field :date,                 type: Date, default: Time.zone.today
     field :record_id,            type: Integer
     field :page_views,           type: Integer, default: 0
@@ -20,6 +18,7 @@ module SupplejackApi
     validates :record_id, uniqueness: { scope: :date }
 
     def self.spawn(record_id, metric, content_partner, date = Time.zone.today)
+      return unless SupplejackApi.config.log_metrics == true
       find_or_create_by(record_id: record_id, date: date, content_partner: content_partner).inc("#{metric}": 1)
     end
   end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -14,5 +14,6 @@ module SupplejackApi
     field :appeared_in_searches, type: Integer, default: 0
 
     validates :record_id, presence: true
+    validates :record_id, uniqueness: { scope: :date }
   end
 end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,12 +5,14 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
-    field :date,                 type: Date
+    field :date,                 type: Date, default: Time.zone.today
     field :record_id,            type: Integer
-    field :page_views,           type: Integer
-    field :user_set_views,       type: Integer
-    field :added_to_user_sets,   type: Integer
-    field :source_clickthroughs,  type: Integer
-    field :appeared_in_searches, type: Integer
+    field :page_views,           type: Integer, default: 0
+    field :user_set_views,       type: Integer, default: 0
+    field :added_to_user_sets,   type: Integer, default: 0
+    field :source_clickthroughs, type: Integer, default: 0
+    field :appeared_in_searches, type: Integer, default: 0
+
+    validates :record_id, presence: true
   end
 end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -11,6 +11,7 @@ module SupplejackApi
     field :record_id,            type: Integer
     field :page_views,           type: Integer, default: 0
     field :user_set_views,       type: Integer, default: 0
+    field :content_partner,      type: Array
     field :added_to_user_sets,   type: Integer, default: 0
     field :source_clickthroughs, type: Integer, default: 0
     field :appeared_in_searches, type: Integer, default: 0
@@ -18,8 +19,8 @@ module SupplejackApi
     validates :record_id, presence: true
     validates :record_id, uniqueness: { scope: :date }
 
-    def self.spawn(record_id, metric, date = Time.zone.today)
-      RecordMetric.find_or_create_by(record_id: record_id, date: date).inc("#{metric}": 1)
+    def self.spawn(record_id, metric, content_partner, date = Time.zone.today)
+      find_or_create_by(record_id: record_id, date: date, content_partner: content_partner).inc("#{metric}": 1)
     end
   end
 end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -18,10 +18,8 @@ module SupplejackApi
     validates :record_id, presence: true
     validates :record_id, uniqueness: { scope: :date }
 
-    class << self
-      def spawn(record_id, metric, date = Time.zone.today)
-        RecordMetric.find_or_create_by(record_id: record_id, date: date).inc("#{metric}": 1)
-      end
+    def self.spawn(record_id, metric, date = Time.zone.today)
+      RecordMetric.find_or_create_by(record_id: record_id, date: date).inc("#{metric}": 1)
     end
   end
 end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  # app/models/supplejack_api/record_metric.rb
+  class RecordMetric
+    include Mongoid::Document
+
+    field :date,                 type: Date
+    field :record_id,            type: Integer
+    field :page_views,           type: Integer
+    field :user_set_views,       type: Integer
+    field :added_to_user_sets,   type: Integer
+    field :source_clickthroughs,  type: Integer
+    field :appeared_in_searches, type: Integer
+  end
+end

--- a/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
@@ -1,43 +1,42 @@
 require 'spec_helper'
 
 describe ApplicationController, type: :controller do
+  class DummySearch < BasicObject
+    def initialize(results)
+      @results = results
+    end
 
-class DummySearch < BasicObject
-  def initialize(results)
-    @results = results
+    def results
+      @results
+    end
+
+    def records
+      @results
+    end
+
+    def valid?
+      true
+    end
   end
 
-  def results
-    @results
-  end
+  controller do
+    include SupplejackApi::Concerns::RecordsControllerMetrics
 
-  def records
-    @results
-  end
+    def index
+      @search = DummySearch.new(SupplejackApi::Record.all.to_a)
+      head :ok
+    end
 
-  def valid?
-    true
-  end
-end
+    def show
+      @record = SupplejackApi::Record.first
+      head :ok
+    end
 
-controller do
-  include SupplejackApi::Concerns::RecordsControllerMetrics
-
-  def index
-    @search = DummySearch.new(SupplejackApi::Record.all.to_a)
-    head :ok
+    def source
+      @record = SupplejackApi::Record.first
+      head :ok
+    end
   end
-
-  def show
-    @record = SupplejackApi::Record.first
-    head :ok
-  end
-
-  def source
-    @record = SupplejackApi::Record.first
-    head :ok
-  end
-end
 
   before do
     create_list(:record_with_fragment, 3)

--- a/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
@@ -32,10 +32,20 @@ controller do
     @record = SupplejackApi::Record.first
     head :ok
   end
+
+  def source
+    @record = SupplejackApi::Record.first
+    head :ok
+  end
 end
 
   before do
     create_list(:record_with_fragment, 3)
+    routes.draw do
+      get 'source' => "anonymous#source"
+      get 'index' => 'anonymous#index'
+      get 'show' => 'anonymous#show'
+    end
   end
 
   describe 'GET#index' do
@@ -76,6 +86,19 @@ end
     it 'does not create an interaction model when ignore_metrics :true' do
       get :show, params: { id: 1, ignore_metrics: true }
       expect(SupplejackApi::InteractionModels::Record.count).to eq 0
+    end
+
+    it 'does not create a page_views SupplejackApi::RecordMetric when ignore_metrics is not set' do
+      get :show, params: { id: 1, ignore_metrics: true }
+      expect(SupplejackApi::RecordMetric.count).to eq 0
+    end
+  end
+
+  describe 'GET#source' do
+    it 'creates a source_clickthrough SupplejackApi::RecordMetric' do
+      get :source
+      expect(SupplejackApi::RecordMetric.count).to eq 1
+      expect(SupplejackApi::RecordMetric.first.source_clickthroughs).to eq 1
     end
   end
 end

--- a/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
@@ -35,14 +35,25 @@ end
   end
 
   describe 'GET#index' do
-    it 'creates an interation model when ignore_metrics is not set' do
-      get :index
-      expect(SupplejackApi::InteractionModels::Record.first.request_type).to eq "search"
+    # TODO: Delete
+    context 'Deprecated implementation' do
+      it 'creates an interation model when ignore_metrics is not set' do
+        get :index
+        expect(SupplejackApi::InteractionModels::Record.first.request_type).to eq "search"
+      end
+
+      it 'does not create an interaction model when ignore_metrics :true' do
+        get :index, params: { ignore_metrics: true }
+        expect(SupplejackApi::InteractionModels::Record.count).to eq 0
+      end
     end
 
-    it 'does not create an interaction model when ignore_metrics :true' do
-      get :index, params: { ignore_metrics: true }
-      expect(SupplejackApi::InteractionModels::Record.count).to eq 0
+    context 'RecordMetric implementation' do
+      it 'creates an appeared_in_searches RecordMetric for each @record in a @search when ignore_metrics is not set' do
+        get :index
+
+
+      end
     end
   end
 

--- a/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
@@ -2,14 +2,10 @@ require 'spec_helper'
 
 describe ApplicationController, type: :controller do
 controller do
-  include SupplejackApi::Concerns::StoriesMetrics
+  include SupplejackApi::Concerns::StoriesControllerMetrics
 
   def show
     @api_response = { payload:  ::StoriesApi::V3::Presenters::Story.new.call(SupplejackApi::UserSet.first) }
-    head :ok
-  end
-
-  def create
     head :ok
   end
 end
@@ -19,14 +15,10 @@ end
   end
 
   describe 'GET#show' do
-    it 'creates a user_set_views SupplejackApi::RecordMetric' do
+    it 'creates a user_story_views SupplejackApi::RecordMetric' do
       get :show, params: { id: 1 }
-    end
-  end
-
-  describe '#create' do
-    it 'creates a added_to_user_sets SupplejackApi::RecordMetric' do
-      post :create, params: { id: 1 }
+      expect(SupplejackApi::RecordMetric.count).to eq 2
+      expect(SupplejackApi::RecordMetric.first.user_story_views).to eq 1
     end
   end
 end

--- a/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe ApplicationController, type: :controller do
-controller do
-  include SupplejackApi::Concerns::StoriesControllerMetrics
+  controller do
+    include SupplejackApi::Concerns::StoriesControllerMetrics
 
-  def show
-    @api_response = { payload:  ::StoriesApi::V3::Presenters::Story.new.call(SupplejackApi::UserSet.first) }
-    head :ok
+    def show
+      @api_response = { payload:  ::StoriesApi::V3::Presenters::Story.new.call(SupplejackApi::UserSet.first) }
+      head :ok
+    end
   end
-end
 
   before do
     create(:story)

--- a/spec/controllers/supplejack_api/concerns/stories_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/stories_metrics_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe ApplicationController, type: :controller do
+controller do
+  include SupplejackApi::Concerns::StoriesMetrics
+
+  def show
+    @api_response = { payload:  ::StoriesApi::V3::Presenters::Story.new.call(SupplejackApi::UserSet.first) }
+    head :ok
+  end
+
+  def create
+    head :ok
+  end
+end
+
+  before do
+    create(:story)
+  end
+
+  describe 'GET#show' do
+    it 'creates a user_set_views SupplejackApi::RecordMetric' do
+      get :show, params: { id: 1 }
+    end
+  end
+
+  describe '#create' do
+    it 'creates a added_to_user_sets SupplejackApi::RecordMetric' do
+      post :create, params: { id: 1 }
+    end
+  end
+end

--- a/spec/controllers/supplejack_api/concerns/story_items_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/story_items_controller_metrics_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe ApplicationController, type: :controller do
+controller do
+  include SupplejackApi::Concerns::StoryItemsControllerMetrics
+
+  def create
+    @api_response = { payload: ::StoriesApi::V3::Presenters::Story.new.call(SupplejackApi::UserSet.first)[:contents].first }
+    head :ok
+  end
+end
+
+  before do
+    create(:story)
+  end
+
+  describe '#create' do
+    it 'creates a added_to_user_stories SupplejackApi::RecordMetric' do
+      post :create, params: { id: 1 }
+      expect(SupplejackApi::RecordMetric.count).to eq 1
+      expect(SupplejackApi::RecordMetric.first.added_to_user_stories).to eq 1
+    end
+  end
+end

--- a/spec/controllers/supplejack_api/concerns/story_items_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/story_items_controller_metrics_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe ApplicationController, type: :controller do
-controller do
-  include SupplejackApi::Concerns::StoryItemsControllerMetrics
+  controller do
+    include SupplejackApi::Concerns::StoryItemsControllerMetrics
 
-  def create
-    @api_response = { payload: ::StoriesApi::V3::Presenters::Story.new.call(SupplejackApi::UserSet.first)[:contents].first }
-    head :ok
+    def create
+      @api_response = { payload: ::StoriesApi::V3::Presenters::Story.new.call(SupplejackApi::UserSet.first)[:contents].first }
+      head :ok
+    end
   end
-end
 
   before do
     create(:story)

--- a/spec/controllers/supplejack_api/concerns/user_sets_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/user_sets_controller_metrics_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe ApplicationController, type: :controller do
+controller do
+  include SupplejackApi::Concerns::UserSetsControllerMetrics
+
+  def show
+    @user_set = SupplejackApi::UserSet.first
+    head :ok
+  end
+
+  def create
+    @user_set = SupplejackApi::UserSet.first
+    head :ok
+  end
+end
+
+  before do
+    create(:user_set_with_set_item)
+  end
+
+  describe 'GET#show' do
+    it 'creates a user_set_views SupplejackApi::RecordMetric' do
+      get :show, params: { id: 1 }
+      expect(SupplejackApi::RecordMetric.count).to eq 1
+      expect(SupplejackApi::RecordMetric.first.user_set_views).to eq 1
+    end
+  end
+
+  describe '#create' do
+    it 'creates a added_to_user_sets SupplejackApi::RecordMetric' do
+      post :create, params: { id: 1 }
+      expect(SupplejackApi::RecordMetric.count).to eq 1
+      expect(SupplejackApi::RecordMetric.first.added_to_user_sets).to eq 1
+    end
+  end
+end

--- a/spec/controllers/supplejack_api/concerns/user_sets_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/user_sets_controller_metrics_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
 describe ApplicationController, type: :controller do
-controller do
-  include SupplejackApi::Concerns::UserSetsControllerMetrics
+  controller do
+    include SupplejackApi::Concerns::UserSetsControllerMetrics
 
-  def show
-    @user_set = SupplejackApi::UserSet.first
-    head :ok
-  end
+    def show
+      @user_set = SupplejackApi::UserSet.first
+      head :ok
+    end
 
-  def create
-    @user_set = SupplejackApi::UserSet.first
-    head :ok
+    def create
+      @user_set = SupplejackApi::UserSet.first
+      head :ok
+    end
   end
-end
 
   before do
     create(:user_set_with_set_item)

--- a/spec/dummy/app/workers/supplejack_api/index_source_worker.rb
+++ b/spec/dummy/app/workers/supplejack_api/index_source_worker.rb
@@ -1,8 +1,8 @@
-# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government, 
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
 # and is licensed under the GNU General Public License, version 3.
-# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and 
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 
 module SupplejackApi

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,8 +1,8 @@
-# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government, 
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
 # and is licensed under the GNU General Public License, version 3.
-# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and 
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
 # the Department of Internal Affairs. http://digitalnz.org/supplejack
 
 require File.expand_path('../boot', __FILE__)
@@ -65,7 +65,7 @@ module Dummy
     # Enable the asset pipeline
     config.assets.enabled = true
 
-    config.time_zone = "Wellington"
+    config.time_zone = "Auckland"
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
@@ -73,4 +73,3 @@ module Dummy
     config.i18n.enforce_available_locales = true
   end
 end
-

--- a/spec/dummy/config/initializers/supplejack_api.rb
+++ b/spec/dummy/config/initializers/supplejack_api.rb
@@ -1,4 +1,5 @@
 SupplejackApi.setup do |config|
   config.record_class = SupplejackApi::Record
   config.preview_record_class = SupplejackApi::PreviewRecord
+  config.log_metrics = true
 end

--- a/spec/factories/record_metric.rb
+++ b/spec/factories/record_metric.rb
@@ -8,13 +8,7 @@
 module SupplejackApi
   FactoryBot.define do
     factory :record_metric, class: SupplejackApi::RecordMetric do
-      date                Date.today
       record_id            1
-      page_views           1
-      user_set_views       1
-      added_to_user_sets   1
-      source_clickthroughs 1
-      appeared_in_searches 1
     end
   end
 end

--- a/spec/factories/record_metric.rb
+++ b/spec/factories/record_metric.rb
@@ -1,0 +1,20 @@
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
+# the Department of Internal Affairs. http://digitalnz.org/supplejack
+
+module SupplejackApi
+  FactoryBot.define do
+    factory :record_metric, class: SupplejackApi::RecordMetric do
+      date                Date.today
+      record_id            1
+      page_views           1
+      user_set_views       1
+      added_to_user_sets   1
+      source_clickthroughs 1
+      appeared_in_searches 1
+    end
+  end
+end

--- a/spec/factories/story_item.rb
+++ b/spec/factories/story_item.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sub_type 'heading'
     content {{value: 'foo', image_url: ('a'..'z').to_a.shuffle.join}}
     meta {{size: 1}}
-    record_id SecureRandom.random_number(1000000)
+    record_id { SecureRandom.random_number(1000000) }
 
     factory :heading_item do
       type 'text'

--- a/spec/factories/story_item.rb
+++ b/spec/factories/story_item.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sub_type 'heading'
     content {{value: 'foo', image_url: ('a'..'z').to_a.shuffle.join}}
     meta {{size: 1}}
-    sequence(:record_id)
+    record_id SecureRandom.random_number(1000000)
 
     factory :heading_item do
       type 'text'

--- a/spec/factories/story_item.rb
+++ b/spec/factories/story_item.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     sub_type 'heading'
     content {{value: 'foo', image_url: ('a'..'z').to_a.shuffle.join}}
     meta {{size: 1}}
+    sequence(:record_id)
 
     factory :heading_item do
       type 'text'

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe SupplejackApi::RecordMetric do
   describe '#attributes' do
-    let(:record_metric) { create(:record_metric) }
+    let(:record_metric) { create(:record_metric, content_partner: ['NDHA']) }
 
     it 'has a date' do
       expect(record_metric.date).to eq Date.today
@@ -18,6 +18,10 @@ RSpec.describe SupplejackApi::RecordMetric do
 
     it 'has user_set_views' do
       expect(record_metric.user_set_views).to eq 0
+    end
+
+    it 'has a content_partner' do
+      expect(record_metric.content_partner).to eq ['NDHA']
     end
 
     it 'has adeed_to_user_sets' do
@@ -56,18 +60,18 @@ RSpec.describe SupplejackApi::RecordMetric do
   end
 
   describe '::spawn' do
-    let!(:record_metric) { create(:record_metric, record_id: 1, page_views: 1) }
+    let!(:record_metric) { create(:record_metric, record_id: 1, page_views: 1, content_partner: ['NDHA']) }
 
     it 'creates a new RecordMetric when there is not one for the provided day and record_id' do
-      expect { SupplejackApi::RecordMetric.spawn(2, :appeared_in_searches) }.to change(SupplejackApi::RecordMetric, :count).by(1)
+      expect { SupplejackApi::RecordMetric.spawn(2, :appeared_in_searches, ['NDHA']) }.to change(SupplejackApi::RecordMetric, :count).by(1)
     end
 
     it 'does not create a RecordMetric when the provided day and record_id allready exist' do
-      expect { SupplejackApi::RecordMetric.spawn(record_metric.record_id, :appeared_in_searches) }.to change(SupplejackApi::RecordMetric, :count).by(0)
+      expect { SupplejackApi::RecordMetric.spawn(record_metric.record_id, :appeared_in_searches, ['NDHA']) }.to change(SupplejackApi::RecordMetric, :count).by(0)
     end
 
     it 'increments an existing Record Metric' do
-      SupplejackApi::RecordMetric.spawn(record_metric.record_id, :page_views)
+      SupplejackApi::RecordMetric.spawn(record_metric.record_id, :page_views, ['NDHA'])
       record_metric.reload
       expect(record_metric.page_views).to eq 2
     end

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -13,23 +13,23 @@ RSpec.describe SupplejackApi::RecordMetric do
     end
 
     it 'has page_views' do
-      expect(record_metric.page_views).to eq 1
+      expect(record_metric.page_views).to eq 0
     end
 
     it 'has user_set_views' do
-      expect(record_metric.user_set_views).to eq 1
+      expect(record_metric.user_set_views).to eq 0
     end
 
     it 'has adeed_to_user_sets' do
-      expect(record_metric.added_to_user_sets).to eq 1
+      expect(record_metric.added_to_user_sets).to eq 0
     end
 
     it 'has source_clickthroughs' do
-      expect(record_metric.source_clickthroughs).to eq 1
+      expect(record_metric.source_clickthroughs).to eq 0
     end
 
     it 'has appeared_in_searches' do
-      expect(record_metric.appeared_in_searches).to eq 1
+      expect(record_metric.appeared_in_searches).to eq 0
     end
   end
 

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -54,4 +54,22 @@ RSpec.describe SupplejackApi::RecordMetric do
       expect(record_metric_three).to be_valid
     end
   end
+
+  describe '::spawn' do
+    let!(:record_metric) { create(:record_metric, record_id: 1, page_views: 1) }
+
+    it 'creates a new RecordMetric when there is not one for the provided day and record_id' do
+      expect { SupplejackApi::RecordMetric.spawn(2, :appeared_in_searches) }.to change(SupplejackApi::RecordMetric, :count).by(1)
+    end
+
+    it 'does not create a RecordMetric when the provided day and record_id allready exist' do
+      expect { SupplejackApi::RecordMetric.spawn(record_metric.record_id, :appeared_in_searches) }.to change(SupplejackApi::RecordMetric, :count).by(0)
+    end
+
+    it 'increments an existing Record Metric' do
+      SupplejackApi::RecordMetric.spawn(record_metric.record_id, :page_views)
+      record_metric.reload
+      expect(record_metric.page_views).to eq 2
+    end
+  end
 end

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupplejackApi::RecordMetric do
     let(:record_metric) { create(:record_metric, content_partner: ['NDHA']) }
 
     it 'has a date' do
-      expect(record_metric.date).to eq Date.today
+      expect(record_metric.date).to eq Time.zone.today
     end
 
     it 'has a record_id' do

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe SupplejackApi::RecordMetric do
-  let(:record_metric) { create(:record_metric) }
-
   describe '#attributes' do
+    let(:record_metric) { create(:record_metric) }
+
     it 'has a date' do
       expect(record_metric.date).to eq Date.today
     end
@@ -34,8 +34,24 @@ RSpec.describe SupplejackApi::RecordMetric do
   end
 
   describe '#validations' do
-    it 'prevents you from creating a RecordMetric that has the same record_id and date' do
+    let(:invalid) { build(:record_metric, record_id: nil) }
 
+    let!(:record_metric) { create(:record_metric) }
+    let(:record_metric_two) { build(:record_metric) }
+    let(:record_metric_three) { build(:record_metric, date: 1.day.from_now) }
+
+    it 'requires a record_id' do
+      invalid.valid?
+      expect(invalid.errors[:record_id]).to include 'Record field can\'t be blank.'
+    end
+
+    it 'does not create a record metric when one allready exists for given id and date' do
+      record_metric_two.valid?
+      expect(record_metric_two.errors[:record_id]).to include 'is already taken'
+    end
+
+    it 'allows record metrics with the same record id on different days' do
+      expect(record_metric_three).to be_valid
     end
   end
 end

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe SupplejackApi::RecordMetric do
       expect(record_metric.content_partner).to eq ['NDHA']
     end
 
+    it 'has user_story_views' do
+      expect(record_metric.user_story_views).to eq 0
+    end
+
     it 'has adeed_to_user_sets' do
       expect(record_metric.added_to_user_sets).to eq 0
     end
@@ -34,6 +38,10 @@ RSpec.describe SupplejackApi::RecordMetric do
 
     it 'has appeared_in_searches' do
       expect(record_metric.appeared_in_searches).to eq 0
+    end
+
+    it 'has added_to_user_stories' do
+      expect(record_metric.added_to_user_stories).to eq 0
     end
   end
 

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe SupplejackApi::RecordMetric do
+  let(:record_metric) { create(:record_metric) }
+
+  describe '#attributes' do
+    it 'has a date' do
+      expect(record_metric.date).to eq Date.today
+    end
+
+    it 'has a record_id' do
+      expect(record_metric.record_id).to eq 1
+    end
+
+    it 'has page_views' do
+      expect(record_metric.page_views).to eq 1
+    end
+
+    it 'has user_set_views' do
+      expect(record_metric.user_set_views).to eq 1
+    end
+
+    it 'has adeed_to_user_sets' do
+      expect(record_metric.added_to_user_sets).to eq 1
+    end
+
+    it 'has source_clickthroughs' do
+      expect(record_metric.source_clickthroughs).to eq 1
+    end
+
+    it 'has appeared_in_searches' do
+      expect(record_metric.appeared_in_searches).to eq 1
+    end
+  end
+
+  describe '#validations' do
+    it 'prevents you from creating a RecordMetric that has the same record_id and date' do
+
+    end
+  end
+end


### PR DESCRIPTION
** Acceptance Criteria **

Metrics are created per record per day and include counts of record_id, date, appeared_in_searches, page_views, user_set_views, added_to_user_sets, source_clickthroughs.