### PR TITLE
Remove fragment save as it breaks the attachment when merging

### DIFF
--- a/app/controllers/supplejack_api/harvester/fragments_controller.rb
+++ b/app/controllers/supplejack_api/harvester/fragments_controller.rb
@@ -18,7 +18,6 @@ module SupplejackApi
         @record = klass.find(params[:record_id])
         @record.create_or_update_fragment(fragment_params)
         @record.set_status(params[:required_fragments])
-        @record.fragments.map(&:save!)
         @record.save!
 
         render json: { status: :success, record_id: @record.record_id }

--- a/app/controllers/supplejack_api/harvester/fragments_controller.rb
+++ b/app/controllers/supplejack_api/harvester/fragments_controller.rb
@@ -22,7 +22,10 @@ module SupplejackApi
 
         @record.save!
 
-        # TODO: This is a potential fix for
+        # TODO: This is a fix for merged fragments dropping their relationship fields
+        # eg attachments. There is most likely a deeper problem with how merged_fragments
+        # are built, or how Mongo relationships cascade after they have been saved.
+        # DO NOT REMOVE unless you understand this issue and have fixed it.
 
         @record.save!
 

--- a/app/controllers/supplejack_api/harvester/fragments_controller.rb
+++ b/app/controllers/supplejack_api/harvester/fragments_controller.rb
@@ -18,6 +18,12 @@ module SupplejackApi
         @record = klass.find(params[:record_id])
         @record.create_or_update_fragment(fragment_params)
         @record.set_status(params[:required_fragments])
+        @record.fragments.map(&:save!)
+
+        @record.save!
+
+        # TODO: This is a potential fix for
+
         @record.save!
 
         render json: { status: :success, record_id: @record.record_id }

--- a/app/models/supplejack_api/concerns/record.rb
+++ b/app/models/supplejack_api/concerns/record.rb
@@ -9,7 +9,7 @@ module SupplejackApi::Concerns::Record
 
     # Associations
     embeds_many :fragments, cascade_callbacks: true, class_name: 'SupplejackApi::ApiRecord::RecordFragment'
-    embeds_one :merged_fragment, class_name: 'SupplejackApi::ApiRecord::RecordFragment'
+    embeds_one :merged_fragment, cascade_callbacks: true, class_name: 'SupplejackApi::ApiRecord::RecordFragment'
     has_and_belongs_to_many :concepts, class_name: 'SupplejackApi::Concept'
 
     # From storable

--- a/app/models/supplejack_api/preview_record.rb
+++ b/app/models/supplejack_api/preview_record.rb
@@ -18,7 +18,7 @@ module SupplejackApi
     store_in collection: 'preview_records'
 
     embeds_many :fragments, cascade_callbacks: true, class_name: 'SupplejackApi::ApiRecord::RecordFragment'
-    embeds_one :merged_fragment, class_name: 'SupplejackApi::ApiRecord::RecordFragment'
+    embeds_one :merged_fragment, cascade_callbacks: true, class_name: 'SupplejackApi::ApiRecord::RecordFragment'
 
     auto_increment :record_id, session: 'strong', collection: 'preview_sequences'
 


### PR DESCRIPTION
Manually enriching the record from the example harvest above is making the correct updates to the fragment. Notice the attachments field in the correct fragment.
But then that attachments field is not being merged through to the merged fragment.
record.save! on that record does trigger a successful merge.