### PR TITLE
CONCEPTS API RAILS PARAMS ISSUE: As a API user I want the pagination to work correctly on the Concepts API, so that I can see past the first page of results.

### DIFF
--- a/app/models/supplejack_api/concept_search.rb
+++ b/app/models/supplejack_api/concept_search.rb
@@ -4,7 +4,7 @@ module SupplejackApi
   class ConceptSearch < Search
     def initialize(options = {})
       @options = options.dup
-      @options.merge!(
+      @options.reverse_merge!(
         and: {},
         or: {},
         without: {},

--- a/app/models/supplejack_api/source_authority.rb
+++ b/app/models/supplejack_api/source_authority.rb
@@ -16,7 +16,7 @@ module SupplejackApi
 
     store_in collection: 'source_authorities'
 
-    field :concept_type,                       type: String
+    field :concept_type,                type: String
     field :internal_identifier,         type: String
     field :concept_score,               type: Integer
     field :source_id,                   type: String


### PR DESCRIPTION
Acceptance Criteria

All Concepts params work correctly.
params

page, facets_per_page, ,facets, facets_page, per_page, text, fields
Example:

https://api.digitalnz.org/concepts.json?api_key=v0aORgQAmQDSPtOJzMGI
Notice the same page of results
https://api.digitalnz.org/concepts.json?api_key=v0aORgQAmQDSPtOJzMGI&page=2