### PR TITLE
IMPROVE METRICS LOGGING PERFORMANCE

### DIFF
--- a/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/records_controller_metrics.rb
@@ -16,9 +16,12 @@ module SupplejackApi
 
           SupplejackApi::InteractionModels::Record.create_search(@search)
 
-          @search.records.each do |record|
-            SupplejackApi::RecordMetric.spawn(record.record_id, :appeared_in_searches, record.display_collection)
-          end
+          SupplejackApi::RequestMetric.spawn(
+            @search.records.map do |record|
+              { record_id: record.record_id, display_collection: record.display_collection }
+            end,
+            'appeared_in_searches'
+          )
         end
 
         def log_record_view
@@ -26,7 +29,12 @@ module SupplejackApi
 
           SupplejackApi::InteractionModels::Record.create_find(@record)
 
-          SupplejackApi::RecordMetric.spawn(@record.record_id, :page_views, @record.display_collection)
+          SupplejackApi::RequestMetric.spawn(
+            [
+              { record_id: @record.record_id, display_collection: @record.display_collection }
+            ],
+            'page_views'
+          )
         end
 
         def log_source_clickthrough
@@ -34,7 +42,12 @@ module SupplejackApi
 
           SupplejackApi::InteractionModels::SourceClickthrough.create(facet: @record.display_collection)
 
-          SupplejackApi::RecordMetric.spawn(@record.record_id, :source_clickthroughs, @record.display_collection)
+          SupplejackApi::RequestMetric.spawn(
+            [
+              { record_id: @record.record_id, display_collection: @record.display_collection }
+            ],
+            'source_clickthroughs'
+          )
         end
       end
     end

--- a/app/controllers/supplejack_api/concerns/stories_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/stories_controller_metrics.rb
@@ -12,10 +12,12 @@ module SupplejackApi
         def create_story_record_views
           return unless @api_response[:payload] && log_request_for_metrics?
 
-          @api_response[:payload][:contents].each do |record|
-            SupplejackApi::RecordMetric.spawn(record[:record_id], :user_story_views,
-                                              record[:content][:display_collection])
-          end
+          SupplejackApi::RequestMetric.spawn(
+            @api_response[:payload][:contents].map do |record|
+              { record_id: record[:record_id], display_collection: record[:content][:display_collection] }
+            end,
+            'user_story_views'
+          )
         end
       end
     end

--- a/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
+++ b/app/controllers/supplejack_api/concerns/story_items_controller_metrics.rb
@@ -13,12 +13,17 @@ module SupplejackApi
           return unless @api_response[:payload] && log_request_for_metrics?
 
           record = @api_response[:payload]
-
           return if record[:record_id].blank?
 
-          SupplejackApi::RecordMetric.spawn(record[:record_id],
-                                            :added_to_user_stories,
-                                            record[:content][:display_collection])
+          SupplejackApi::RequestMetric.spawn(
+            [
+              {
+                record_id: record[:record_id],
+                display_collection: record[:content][:display_collection]
+              }
+            ],
+            'added_to_user_stories'
+          )
         end
       end
     end

--- a/app/models/supplejack_api/collection_metric.rb
+++ b/app/models/supplejack_api/collection_metric.rb
@@ -5,7 +5,7 @@ module SupplejackApi
   class CollectionMetric
     include Mongoid::Document
 
-    field :d, as: :date,                               type: Date,    default: Time.zone.now.utc
+    field :d, as: :date,                               type: Date,    default: Time.current.utc
     field :dc, as: :display_collection,                type: String
     field :s, as: :searches,                           type: Integer, default: 0
     field :rpv, as: :record_page_views,                type: Integer, default: 0

--- a/app/models/supplejack_api/collection_metric.rb
+++ b/app/models/supplejack_api/collection_metric.rb
@@ -5,7 +5,7 @@ module SupplejackApi
   class CollectionMetric
     include Mongoid::Document
 
-    field :d, as: :date,                               type: Date,    default: Time.zone.today
+    field :d, as: :date,                               type: Date,    default: Time.zone.now.utc
     field :dc, as: :display_collection,                type: String
     field :s, as: :searches,                           type: Integer, default: 0
     field :rpv, as: :record_page_views,                type: Integer, default: 0

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -21,9 +21,9 @@ module SupplejackApi
 
     index({ date: 1, content_partner: 1, record_id: 1 }, background: true)
 
-    def self.spawn(record_id, metric, display_collection, date = Time.zone.today)
+    def self.spawn(record_id, metrics, display_collection, date = Time.zone.today)
       return unless SupplejackApi.config.log_metrics == true
-      find_or_create_by(record_id: record_id, date: date, display_collection: display_collection).inc("#{metric}": 1)
+      find_or_create_by(record_id: record_id, date: date, display_collection: display_collection).inc(metrics)
     end
   end
 end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -19,7 +19,7 @@ module SupplejackApi
     validates :record_id, presence: true
     validates :record_id, uniqueness: { scope: :date }
 
-    index({ date: 1, content_partner: 1, record_id: 1 }, background: true)
+    index({ date: 1, display_collection: 1, record_id: 1 }, background: true)
 
     def self.spawn(record_id, metrics, display_collection, date = Time.current.utc)
       return unless SupplejackApi.config.log_metrics == true
@@ -27,3 +27,11 @@ module SupplejackApi
     end
   end
 end
+
+
+
+# puts (Benchmark.measure do
+#   test.each do |id, details|
+#     SupplejackApi::RecordMetric.collection.update_one({ record_id: id, date: Time.now.utc.to_date, display_collection: details['display_collection']}, { '$inc' => details['metrics']}, { upsert: true })
+#   end
+# end)

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,7 +5,7 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
-    field :date,                  type: Date,    default: Time.zone.now.utc
+    field :date,                  type: Date,    default: Time.current.utc
     field :record_id,             type: Integer
     field :page_views,            type: Integer, default: 0
     field :user_set_views,        type: Integer, default: 0
@@ -21,7 +21,7 @@ module SupplejackApi
 
     index({ date: 1, content_partner: 1, record_id: 1 }, background: true)
 
-    def self.spawn(record_id, metrics, display_collection, date = Time.zone.now.utc)
+    def self.spawn(record_id, metrics, display_collection, date = Time.current.utc)
       return unless SupplejackApi.config.log_metrics == true
       find_or_create_by(record_id: record_id, date: date, display_collection: display_collection).inc(metrics)
     end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,7 +5,7 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
-    field :date,                  type: Date,    default: Time.zone.today
+    field :date,                  type: Date,    default: Time.zone.now.utc
     field :record_id,             type: Integer
     field :page_views,            type: Integer, default: 0
     field :user_set_views,        type: Integer, default: 0
@@ -21,7 +21,7 @@ module SupplejackApi
 
     index({ date: 1, content_partner: 1, record_id: 1 }, background: true)
 
-    def self.spawn(record_id, metrics, display_collection, date = Time.zone.today)
+    def self.spawn(record_id, metrics, display_collection, date = Time.zone.now.utc)
       return unless SupplejackApi.config.log_metrics == true
       find_or_create_by(record_id: record_id, date: date, display_collection: display_collection).inc(metrics)
     end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -19,7 +19,7 @@ module SupplejackApi
     validates :record_id, presence: true
     validates :record_id, uniqueness: { scope: :date }
 
-    index({ date: 1, display_collection: 1, record_id: 1 }, background: true)
+    index({ record_id: 1, display_collection: 1, date: 1 }, background: true)
 
     def self.spawn(record_id, metrics, display_collection, date = Time.current.utc)
       return unless SupplejackApi.config.log_metrics == true

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,7 +5,7 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
-    field :date,                  type: Date,    default: Time.current.utc
+    field :date,                  type: Date,    default: Time.current.utc.to_date
     field :record_id,             type: Integer
     field :page_views,            type: Integer, default: 0
     field :user_set_views,        type: Integer, default: 0
@@ -21,17 +21,13 @@ module SupplejackApi
 
     index({ record_id: 1, display_collection: 1, date: 1 }, background: true)
 
-    def self.spawn(record_id, metrics, display_collection, date = Time.current.utc)
+    def self.spawn(record_id, metrics, display_collection, date = Time.current.utc.to_date)
       return unless SupplejackApi.config.log_metrics == true
-      find_or_create_by(record_id: record_id, date: date, display_collection: display_collection).inc(metrics)
+      collection.update_one({
+        record_id: record_id,
+        date: date.to_date,
+        display_collection: display_collection
+      }, { '$inc' => metrics }, upsert: true)
     end
   end
 end
-
-
-
-# puts (Benchmark.measure do
-#   test.each do |id, details|
-#     SupplejackApi::RecordMetric.collection.update_one({ record_id: id, date: Time.now.utc.to_date, display_collection: details['display_collection']}, { '$inc' => details['metrics']}, { upsert: true })
-#   end
-# end)

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -12,6 +12,19 @@ module SupplejackApi
     validates :records, presence: true
     validates :metric,  presence: true
 
+    EMPTY_RECORD_METRIC = {
+      'metrics' => {
+        'page_views' => 0,
+        'user_set_views' => 0,
+        'user_story_views' => 0,
+        'added_to_user_sets' => 0,
+        'source_clickthroughs' => 0,
+        'appeared_in_searches' => 0,
+        'added_to_user_stories' => 0
+      },
+      'display_collection' => 'none'
+    }.freeze
+
     def self.spawn(records, metric, date = Time.zone.today)
       return unless SupplejackApi.config.log_metrics == true
       create(records: records, metric: metric, date: date)
@@ -26,18 +39,7 @@ module SupplejackApi
         summary[date] = {}
 
         uniq_records.each do |record|
-          summary[date][record['record_id']] = {
-            'metrics' => {
-              'page_views' => 0,
-              'user_set_views' => 0,
-              'user_story_views' => 0,
-              'added_to_user_sets' => 0,
-              'source_clickthroughs' => 0,
-              'appeared_in_searches' => 0,
-              'added_to_user_stories' => 0
-            },
-            'display_collection' => 'none'
-          }
+          summary[date][record['record_id']] = EMPTY_RECORD_METRIC
         end
 
         # Group them by metric

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  # app/models/supplejack_api/request_metric.rb
+  class RequestMetric
+    include Mongoid::Document
+
+    field :date,    type: Date,   default: Time.zone.today
+    field :records, type: Array,  default: []
+    field :metric,  type: String
+
+    validates :records, presence: true
+    validates :metric,  presence: true
+
+    def self.spawn(records, metric, date = Time.zone.today)
+      return unless SupplejackApi.config.log_metrics == true
+      create(records: records, metric: metric, date: date)
+    end
+
+    def self.summarize
+      return unless SupplejackApi.config.log_metrics == true
+
+      # Split the requests by date
+      summarized_metrics = all.group_by(&:date).each_with_object({}) do |(date, metrics), summary|
+        uniq_records = metrics.flat_map(&:records).uniq
+        summary[date] = {}
+
+        uniq_records.each do |record|
+          summary[date][record['record_id']] = {
+            'metrics' => {
+              'page_views' => 0,
+              'user_set_views' => 0,
+              'user_story_views' => 0,
+              'added_to_user_sets' => 0,
+              'source_clickthroughs' => 0,
+              'appeared_in_searches' => 0,
+              'added_to_user_stories' => 0
+            },
+            'display_collection' => 'none'
+          }
+        end
+
+        # Group them by metric
+        metrics.group_by(&:metric).each do |metric, results|
+          metric_total_records = results.flat_map(&:records)
+          metric_uniq_records = metric_total_records.uniq
+
+          # Total the number of records within a date/metric
+          metric_uniq_records.map do |record|
+            record_id = record['record_id']
+            summary[date][record_id]['metrics'][metric] = metric_total_records.count(record)
+            summary[date][record_id]['display_collection'] = record['display_collection']
+          end
+        end
+      end
+
+      # Generate Record Metrics
+      summarized_metrics.each do |date, record|
+        record.each do |id, details|
+          RecordMetric.spawn(id, details['metrics'], details['display_collection'], date)
+        end
+      end
+
+      all.destroy
+    end
+  end
+end

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -21,7 +21,8 @@ module SupplejackApi
     def self.summarize
       return unless SupplejackApi.config.log_metrics == true
 
-      summarized_metrics = all.group_by(&:date).each_with_object({}) do |(date, metrics), summary|
+      records = all.to_a
+      summarized_metrics = records.group_by(&:date).each_with_object({}) do |(date, metrics), summary|
         summary[date] = Hash.new do |hash, key|
           hash[key] = {
             'metrics' => {
@@ -51,7 +52,7 @@ module SupplejackApi
         end
       end
 
-      all.destroy
+      records.map(&:destroy)
     end
     # rubocop:enable Metrics/MethodLength
   end

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -5,7 +5,7 @@ module SupplejackApi
   class RequestMetric
     include Mongoid::Document
 
-    field :date,    type: Date,   default: Time.zone.today
+    field :date,    type: Date,   default: Time.zone.now.utc
     field :records, type: Array,  default: []
     field :metric,  type: String
 

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -12,24 +12,12 @@ module SupplejackApi
     validates :records, presence: true
     validates :metric,  presence: true
 
-    EMPTY_RECORD_METRIC = {
-      'metrics' => {
-        'page_views' => 0,
-        'user_set_views' => 0,
-        'user_story_views' => 0,
-        'added_to_user_sets' => 0,
-        'source_clickthroughs' => 0,
-        'appeared_in_searches' => 0,
-        'added_to_user_stories' => 0
-      },
-      'display_collection' => 'none'
-    }.freeze
-
     def self.spawn(records, metric, date = Time.zone.today)
       return unless SupplejackApi.config.log_metrics == true
       create(records: records, metric: metric, date: date)
     end
 
+    # rubocop:disable Metrics/MethodLength
     def self.summarize
       return unless SupplejackApi.config.log_metrics == true
 
@@ -39,7 +27,18 @@ module SupplejackApi
         summary[date] = {}
 
         uniq_records.each do |record|
-          summary[date][record['record_id']] = EMPTY_RECORD_METRIC
+          summary[date][record['record_id']] = {
+            'metrics' => {
+              'page_views' => 0,
+              'user_set_views' => 0,
+              'user_story_views' => 0,
+              'added_to_user_sets' => 0,
+              'source_clickthroughs' => 0,
+              'appeared_in_searches' => 0,
+              'added_to_user_stories' => 0
+            },
+            'display_collection' => 'none'
+          }
         end
 
         # Group them by metric
@@ -65,5 +64,6 @@ module SupplejackApi
 
       all.destroy
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -5,14 +5,14 @@ module SupplejackApi
   class RequestMetric
     include Mongoid::Document
 
-    field :date,    type: Date,   default: Time.zone.now.utc
+    field :date,    type: Date,   default: Time.current.utc
     field :records, type: Array,  default: []
     field :metric,  type: String
 
     validates :records, presence: true
     validates :metric,  presence: true
 
-    def self.spawn(records, metric, date = Time.zone.today)
+    def self.spawn(records, metric, date = Time.current.utc)
       return unless SupplejackApi.config.log_metrics == true
       create(records: records, metric: metric, date: date)
     end

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -21,13 +21,9 @@ module SupplejackApi
     def self.summarize
       return unless SupplejackApi.config.log_metrics == true
 
-      # Split the requests by date
       summarized_metrics = all.group_by(&:date).each_with_object({}) do |(date, metrics), summary|
-        uniq_records = metrics.flat_map(&:records).uniq
-        summary[date] = {}
-
-        uniq_records.each do |record|
-          summary[date][record['record_id']] = {
+        summary[date] = Hash.new do |hash, key|
+          hash[key] = {
             'metrics' => {
               'page_views' => 0,
               'user_set_views' => 0,
@@ -41,21 +37,14 @@ module SupplejackApi
           }
         end
 
-        # Group them by metric
-        metrics.group_by(&:metric).each do |metric, results|
-          metric_total_records = results.flat_map(&:records)
-          metric_uniq_records = metric_total_records.uniq
-
-          # Total the number of records within a date/metric
-          metric_uniq_records.map do |record|
-            record_id = record['record_id']
-            summary[date][record_id]['metrics'][metric] = metric_total_records.count(record)
-            summary[date][record_id]['display_collection'] = record['display_collection']
+        metrics.each do |metric|
+          metric.records.each do |record|
+            summary[date][record['record_id']]['metrics'][metric.metric] += 1
+            summary[date][record['record_id']]['display_collection'] = record['display_collection']
           end
         end
       end
 
-      # Generate Record Metrics
       summarized_metrics.each do |date, record|
         record.each do |id, details|
           RecordMetric.spawn(id, details['metrics'], details['display_collection'], date)

--- a/app/models/supplejack_api/top_metric.rb
+++ b/app/models/supplejack_api/top_metric.rb
@@ -23,7 +23,7 @@ module SupplejackApi
       added_to_user_stories
     ].freeze
 
-    field :d, as: :date,    type: Date, default: Time.zone.now.utc
+    field :d, as: :date,    type: Date, default: Time.current.utc
     field :m, as: :metric,  type: String
     field :r, as: :results, type: Hash
 

--- a/app/models/supplejack_api/top_metric.rb
+++ b/app/models/supplejack_api/top_metric.rb
@@ -23,7 +23,7 @@ module SupplejackApi
       added_to_user_stories
     ].freeze
 
-    field :d, as: :date,    type: Date, default: Time.zone.today
+    field :d, as: :date,    type: Date, default: Time.zone.now.utc
     field :m, as: :metric,  type: String
     field :r, as: :results, type: Hash
 
@@ -47,12 +47,12 @@ module SupplejackApi
           )
 
           if metric.results.blank?
-            metric.update_attributes(results: results)
+            metric.update(results: results)
           else
             merged_results = metric.results.merge(results) { |_key, a, b| a + b }
             merged_results = merged_results.sort_by { |_k, v| -v }.first(200).to_h
 
-            metric.update_attributes(results: merged_results)
+            metric.update(results: merged_results)
           end
         end
       end

--- a/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
@@ -58,7 +58,7 @@ describe ApplicationController, type: :controller do
       expect(SupplejackApi::InteractionModels::Record.count).to eq 0
     end
 
-    it 'creates an appeared_in_searches SupplejackApi::RecordMetric for each @record in a @search when ignore_metrics is not set' do
+    it 'creates an appeared_in_searches SupplejackApi::RequestMetric for each @record in a @search when ignore_metrics is not set' do
       get :index
       expect(SupplejackApi::RequestMetric.count).to eq 1
       expect(SupplejackApi::RequestMetric.first.metric).to eq 'appeared_in_searches'
@@ -67,7 +67,7 @@ describe ApplicationController, type: :controller do
       expect(SupplejackApi::RequestMetric.first.records.map { |x| x['display_collection'] }).to eq SupplejackApi::Record.all.map(&:display_collection)
     end
 
-    it 'does not create an appeared_in_searches SupplejackApi::RecordMetric when ignore_metrics is set' do
+    it 'does not create an appeared_in_searches SupplejackApi::RequestMetric when ignore_metrics is set' do
       get :index, params: { ignore_metrics: true }
       expect(SupplejackApi::RequestMetric.count).to eq 0
     end
@@ -79,7 +79,7 @@ describe ApplicationController, type: :controller do
       expect(SupplejackApi::InteractionModels::Record.first.request_type).to eq "get"
     end
 
-    it 'creates a page_views SupplejackApi::RecordMetric when ignore_metrics is not set' do
+    it 'creates a page_views SupplejackApi::RequestMetric when ignore_metrics is not set' do
       get :show, params: { id: 1 }
       expect(SupplejackApi::RequestMetric.count).to eq 1
       expect(SupplejackApi::RequestMetric.first.records).to eq [{"record_id"=>1, "display_collection"=>"test"}]
@@ -91,14 +91,14 @@ describe ApplicationController, type: :controller do
       expect(SupplejackApi::InteractionModels::Record.count).to eq 0
     end
 
-    it 'does not create a page_views SupplejackApi::RecordMetric when ignore_metrics is not set' do
+    it 'does not create a page_views SupplejackApi::RequestMetric when ignore_metrics is not set' do
       get :show, params: { id: 1, ignore_metrics: true }
       expect(SupplejackApi::RequestMetric.count).to eq 0
     end
   end
 
   describe 'GET#source' do
-    it 'creates a source_clickthrough SupplejackApi::RecordMetric' do
+    it 'creates a source_clickthrough SupplejackApi::RequestMetric' do
       get :source
       expect(SupplejackApi::RequestMetric.count).to eq 1
       expect(SupplejackApi::RequestMetric.first.records).to eq [{"record_id"=>1, "display_collection"=>"test"}]

--- a/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/records_controller_metrics_spec.rb
@@ -60,13 +60,16 @@ describe ApplicationController, type: :controller do
 
     it 'creates an appeared_in_searches SupplejackApi::RecordMetric for each @record in a @search when ignore_metrics is not set' do
       get :index
-      expect(SupplejackApi::RecordMetric.count).to eq SupplejackApi::Record.count
-      expect(SupplejackApi::RecordMetric.all.map(&:appeared_in_searches)).to eq [1, 1, 1]
+      expect(SupplejackApi::RequestMetric.count).to eq 1
+      expect(SupplejackApi::RequestMetric.first.metric).to eq 'appeared_in_searches'
+      expect(SupplejackApi::RequestMetric.first.records.map { |x| x['record_id'] }).to eq SupplejackApi::Record.all.map(&:record_id)
+
+      expect(SupplejackApi::RequestMetric.first.records.map { |x| x['display_collection'] }).to eq SupplejackApi::Record.all.map(&:display_collection)
     end
 
     it 'does not create an appeared_in_searches SupplejackApi::RecordMetric when ignore_metrics is set' do
       get :index, params: { ignore_metrics: true }
-      expect(SupplejackApi::RecordMetric.count).to eq 0
+      expect(SupplejackApi::RequestMetric.count).to eq 0
     end
   end
 
@@ -78,8 +81,9 @@ describe ApplicationController, type: :controller do
 
     it 'creates a page_views SupplejackApi::RecordMetric when ignore_metrics is not set' do
       get :show, params: { id: 1 }
-      expect(SupplejackApi::RecordMetric.count).to eq 1
-      expect(SupplejackApi::RecordMetric.last.page_views).to eq 1
+      expect(SupplejackApi::RequestMetric.count).to eq 1
+      expect(SupplejackApi::RequestMetric.first.records).to eq [{"record_id"=>1, "display_collection"=>"test"}]
+      expect(SupplejackApi::RequestMetric.first.metric).to eq 'page_views'
     end
 
     it 'does not create an interaction model when ignore_metrics :true' do
@@ -89,15 +93,16 @@ describe ApplicationController, type: :controller do
 
     it 'does not create a page_views SupplejackApi::RecordMetric when ignore_metrics is not set' do
       get :show, params: { id: 1, ignore_metrics: true }
-      expect(SupplejackApi::RecordMetric.count).to eq 0
+      expect(SupplejackApi::RequestMetric.count).to eq 0
     end
   end
 
   describe 'GET#source' do
     it 'creates a source_clickthrough SupplejackApi::RecordMetric' do
       get :source
-      expect(SupplejackApi::RecordMetric.count).to eq 1
-      expect(SupplejackApi::RecordMetric.first.source_clickthroughs).to eq 1
+      expect(SupplejackApi::RequestMetric.count).to eq 1
+      expect(SupplejackApi::RequestMetric.first.records).to eq [{"record_id"=>1, "display_collection"=>"test"}]
+      expect(SupplejackApi::RequestMetric.first.metric).to eq 'source_clickthroughs'
     end
   end
 end

--- a/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
@@ -10,15 +10,15 @@ describe ApplicationController, type: :controller do
     end
   end
 
-  before do
-    create(:story)
-  end
+  let!(:story) { create(:story) }
 
   describe 'GET#show' do
     it 'creates a user_story_views SupplejackApi::RecordMetric' do
       get :show, params: { id: 1 }
-      expect(SupplejackApi::RecordMetric.count).to eq 2
-      expect(SupplejackApi::RecordMetric.first.user_story_views).to eq 1
+
+      expect(SupplejackApi::RequestMetric.count).to eq 1
+      expect(SupplejackApi::RequestMetric.first.records.map { |x| x[:record_id] }).to eq story.set_items.map(&:record_id)
+      expect(SupplejackApi::RequestMetric.first.records.map { |x| x[:display_collection] }).to eq story.set_items.map { |x| x[:content][:display_collection] }
     end
   end
 end

--- a/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
@@ -19,6 +19,7 @@ describe ApplicationController, type: :controller do
       expect(SupplejackApi::RequestMetric.count).to eq 1
       expect(SupplejackApi::RequestMetric.first.records.map { |x| x[:record_id] }).to eq story.set_items.map(&:record_id)
       expect(SupplejackApi::RequestMetric.first.records.map { |x| x[:display_collection] }).to eq story.set_items.map { |x| x[:content][:display_collection] }
+      expect(SupplejackApi::RequestMetric.first.metric).to eq 'user_story_views'
     end
   end
 end

--- a/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/stories_controller_metrics_spec.rb
@@ -13,7 +13,7 @@ describe ApplicationController, type: :controller do
   let!(:story) { create(:story) }
 
   describe 'GET#show' do
-    it 'creates a user_story_views SupplejackApi::RecordMetric' do
+    it 'creates a user_story_views SupplejackApi::RequestMetric' do
       get :show, params: { id: 1 }
 
       expect(SupplejackApi::RequestMetric.count).to eq 1

--- a/spec/controllers/supplejack_api/concerns/story_items_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/story_items_controller_metrics_spec.rb
@@ -10,15 +10,16 @@ describe ApplicationController, type: :controller do
     end
   end
 
-  before do
-    create(:story)
-  end
+  let!(:story) { create(:story) }
 
   describe '#create' do
-    it 'creates a added_to_user_stories SupplejackApi::RecordMetric' do
+    it 'creates a added_to_user_stories SupplejackApi::RequestMetric' do
       post :create, params: { id: 1 }
-      expect(SupplejackApi::RecordMetric.count).to eq 1
-      expect(SupplejackApi::RecordMetric.first.added_to_user_stories).to eq 1
+      expect(SupplejackApi::RequestMetric.count).to eq 1
+
+      expect(SupplejackApi::RequestMetric.first.metric).to eq 'added_to_user_stories'
+      expect(SupplejackApi::RequestMetric.first.records.first.values).to include story.set_items.first.record_id
+      expect(SupplejackApi::RequestMetric.first.records.first.values).to include story.set_items.first.content[:display_collection]
     end
   end
 end

--- a/spec/controllers/supplejack_api/concerns/user_sets_controller_metrics_spec.rb
+++ b/spec/controllers/supplejack_api/concerns/user_sets_controller_metrics_spec.rb
@@ -21,10 +21,11 @@ describe ApplicationController, type: :controller do
         create(:user_set_with_set_item)
       end
 
-      it 'creates a user_set_views SupplejackApi::RecordMetric' do
+      it 'creates a user_set_views SupplejackApi::RequestMetric' do
         get :show, params: { id: 1 }
-        expect(SupplejackApi::RecordMetric.count).to eq 1
-        expect(SupplejackApi::RecordMetric.first.user_set_views).to eq 1
+        expect(SupplejackApi::RequestMetric.count).to eq 1
+        expect(SupplejackApi::RequestMetric.first.metric).to eq 'user_set_views'
+        expect(SupplejackApi::RequestMetric.first.records).to eq  [{"record_id"=>2, "display_collection"=>"test"}]
       end
     end
 
@@ -36,7 +37,7 @@ describe ApplicationController, type: :controller do
 
       it 'does not die when requesting a record that has status deleted' do
         get :show, params: { id: 1 }
-        expect(SupplejackApi::RecordMetric.count).to eq 0
+        expect(SupplejackApi::RequestMetric.count).to eq 0
       end
     end
   end
@@ -47,10 +48,11 @@ describe ApplicationController, type: :controller do
         create(:user_set_with_set_item)
       end
 
-      it 'creates a added_to_user_sets SupplejackApi::RecordMetric' do
+      it 'creates a added_to_user_sets SupplejackApi::RequestMetric' do
         post :create, params: { id: 1 }
-        expect(SupplejackApi::RecordMetric.count).to eq 1
-        expect(SupplejackApi::RecordMetric.first.added_to_user_sets).to eq 1
+        expect(SupplejackApi::RequestMetric.count).to eq 1
+        expect(SupplejackApi::RequestMetric.first.records).to eq [{"record_id"=>2, "display_collection"=>"test"}]
+        expect(SupplejackApi::RequestMetric.first.metric).to eq 'added_to_user_sets'
       end
     end
 
@@ -62,7 +64,7 @@ describe ApplicationController, type: :controller do
 
       it 'does not die when requesting a record that has status deleted' do
         post :create, params: { id: 1 }
-        expect(SupplejackApi::RecordMetric.count).to eq 0
+        expect(SupplejackApi::RequestMetric.count).to eq 0
       end
     end
   end

--- a/spec/factories/record_metric.rb
+++ b/spec/factories/record_metric.rb
@@ -1,5 +1,3 @@
-
-
 module SupplejackApi
   FactoryBot.define do
     factory :record_metric, class: SupplejackApi::RecordMetric do

--- a/spec/factories/request_metric.rb
+++ b/spec/factories/request_metric.rb
@@ -1,0 +1,19 @@
+module SupplejackApi
+  FactoryBot.define do
+    factory :request_metric, class: SupplejackApi::RequestMetric do
+      metric 'appeared_in_searches'
+      records [
+        { record_id: 1001,
+          display_collection: 'TAPHUI' },
+        { record_id: 289,
+          display_collection: 'Papers Past' },
+        { record_id: 289,
+          display_collection: 'Papers Past' },
+        { record_id: 30,
+          display_collection: 'TAPHUI' },
+        { record_id: 411,
+          display_collection: 'National Library of New Zealand' }
+      ]
+    end
+  end
+end

--- a/spec/factories/story_item.rb
+++ b/spec/factories/story_item.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     sequence(:position)
     type 'text'
     sub_type 'heading'
-    content {{value: 'foo', image_url: ('a'..'z').to_a.shuffle.join}}
+    content {{value: 'foo', image_url: ('a'..'z').to_a.shuffle.join, display_collection: 'TAPHUI'}}
     meta {{size: 1}}
     record_id { SecureRandom.random_number(1000000) }
 

--- a/spec/factories/user_sets.rb
+++ b/spec/factories/user_sets.rb
@@ -1,5 +1,3 @@
-
-
 module SupplejackApi
   FactoryBot.define do
     factory :user_set, class: SupplejackApi::UserSet do
@@ -21,7 +19,7 @@ module SupplejackApi
 
     factory :set_item, class: SupplejackApi::SetItem do
       before(:create) do |set_item|
-        record = create(:record)
+        record = create(:record_with_fragment)
         set_item.record_id = record.record_id
       end
       sequence(:position)

--- a/spec/models/supplejack_api/collection_metric_spec.rb
+++ b/spec/models/supplejack_api/collection_metric_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SupplejackApi::CollectionMetric do
     let!(:collection_metric) { create(:collection_metric, searches: 2, record_page_views: 10, user_set_views: 6, user_story_views: 11 ) }
 
     it 'has a date' do
-      expect(collection_metric.date).to eq Time.zone.today
+      expect(collection_metric.date).to eq Time.zone.now.utc.to_date
     end
 
     it 'has a facet' do
@@ -65,14 +65,14 @@ RSpec.describe SupplejackApi::CollectionMetric do
   describe '#spawn' do
     let!(:record_metrics_today) { create_list(:record_metric, 5, page_views: 4, user_set_views: 5, display_collection: 'TAPUHI', user_story_views: 6, added_to_user_sets: 7, source_clickthroughs: 8, appeared_in_searches: 9, added_to_user_stories: 10) }
 
-    let!(:record_metrics_tomorrow) { create_list(:record_metric, 5, date: Time.zone.tomorrow, page_views: 11, display_collection: 'TAPUHI', user_set_views: 12, user_story_views: 13, added_to_user_sets: 14, source_clickthroughs: 15, appeared_in_searches: 16, added_to_user_stories: 17) }
+    let!(:record_metrics_tomorrow) { create_list(:record_metric, 5, date: 1.day.from_now.utc, page_views: 11, display_collection: 'TAPUHI', user_set_views: 12, user_story_views: 13, added_to_user_sets: 14, source_clickthroughs: 15, appeared_in_searches: 16, added_to_user_stories: 17) }
 
     before do
       SupplejackApi::CollectionMetric.spawn
     end
 
     it 'generates per day collection metrics' do
-      todays_collection_metric = SupplejackApi::CollectionMetric.find_by(date: Time.zone.today)
+      todays_collection_metric = SupplejackApi::CollectionMetric.find_by(date: Time.now.utc)
 
       expect(todays_collection_metric.searches).to eq 45
       expect(todays_collection_metric.record_page_views).to eq 20
@@ -84,7 +84,7 @@ RSpec.describe SupplejackApi::CollectionMetric do
     end
 
     it 'generates all available SupplejackApi::CollectionMetric days' do
-      tomorrows_collection_metric = SupplejackApi::CollectionMetric.find_by(date: Time.zone.tomorrow)
+      tomorrows_collection_metric = SupplejackApi::CollectionMetric.find_by(date: 1.day.from_now.utc)
 
       expect(tomorrows_collection_metric.searches).to eq 80
       expect(tomorrows_collection_metric.record_page_views).to eq 55
@@ -100,7 +100,7 @@ RSpec.describe SupplejackApi::CollectionMetric do
 
       SupplejackApi::CollectionMetric.spawn
 
-      more_collection_metric = SupplejackApi::CollectionMetric.find_by(date: Time.zone.today)
+      more_collection_metric = SupplejackApi::CollectionMetric.find_by(date: Time.now.utc)
 
       expect(more_collection_metric.searches).to eq 150
       expect(more_collection_metric.record_page_views).to eq 75
@@ -118,7 +118,7 @@ RSpec.describe SupplejackApi::CollectionMetric do
 
       SupplejackApi::CollectionMetric.spawn
 
-      more_collection_metric = SupplejackApi::CollectionMetric.find_by(date: Time.zone.today)
+      more_collection_metric = SupplejackApi::CollectionMetric.find_by(date: Time.now.utc)
 
       expect(more_collection_metric.searches).to eq 105
       expect(more_collection_metric.record_page_views).to eq 55

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -71,17 +71,26 @@ RSpec.describe SupplejackApi::RecordMetric do
     let!(:record_metric) { create(:record_metric, record_id: 1, page_views: 1, display_collection: 'NDHA') }
 
     it 'creates a new RecordMetric when there is not one for the provided day and record_id' do
-      expect { SupplejackApi::RecordMetric.spawn(2, :appeared_in_searches, 'NDHA') }.to change(SupplejackApi::RecordMetric, :count).by(1)
+      expect { SupplejackApi::RecordMetric.spawn(2, { 'appeared_in_searches' => 1 }, 'NDHA') }.to change(SupplejackApi::RecordMetric, :count).by(1)
     end
 
     it 'does not create a RecordMetric when the provided day and record_id allready exist' do
-      expect { SupplejackApi::RecordMetric.spawn(record_metric.record_id, :appeared_in_searches, 'NDHA') }.to change(SupplejackApi::RecordMetric, :count).by(0)
+      expect { SupplejackApi::RecordMetric.spawn(record_metric.record_id, { 'appeared_in_searches' => 1 }, 'NDHA') }.to change(SupplejackApi::RecordMetric, :count).by(0)
     end
 
     it 'increments an existing Record Metric' do
-      SupplejackApi::RecordMetric.spawn(record_metric.record_id, :page_views, 'NDHA')
+      SupplejackApi::RecordMetric.spawn(record_metric.record_id, { 'page_views' => 1 }, 'NDHA')
       record_metric.reload
       expect(record_metric.page_views).to eq 2
+    end
+
+    it 'increments an existing Record Metric by a given hash of metrics' do
+      SupplejackApi::RecordMetric.spawn(record_metric.record_id, { 'page_views' => 7, 'appeared_in_searches' => 6, 'user_set_views' => 10 }, 'NDHA')
+      record_metric.reload
+
+      expect(record_metric.page_views).to eq 8
+      expect(record_metric.appeared_in_searches).to eq 6
+      expect(record_metric.user_set_views).to eq 10
     end
   end
 end

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupplejackApi::RecordMetric do
     let(:record_metric) { create(:record_metric, display_collection: 'NDHA', record_id: 1) }
 
     it 'has a date' do
-      expect(record_metric.date).to eq Time.zone.today
+      expect(record_metric.date).to eq Time.zone.now.utc.to_date
     end
 
     it 'has a record_id' do
@@ -48,9 +48,9 @@ RSpec.describe SupplejackApi::RecordMetric do
   describe '#validations' do
     let(:invalid) { build(:record_metric, record_id: nil) }
 
-    let!(:record_metric) { create(:record_metric) }
-    let(:record_metric_two) { build(:record_metric, record_id: record_metric.record_id) }
-    let(:record_metric_three) { build(:record_metric, date: 1.day.from_now) }
+    let!(:record_metric)      { create(:record_metric) }
+    let(:record_metric_two)   { build(:record_metric, record_id: record_metric.record_id) }
+    let(:record_metric_three) { build(:record_metric, date: 1.day.from_now.utc) }
 
     it 'requires a record_id' do
       invalid.valid?

--- a/spec/models/supplejack_api/request_metric_spec.rb
+++ b/spec/models/supplejack_api/request_metric_spec.rb
@@ -25,10 +25,9 @@ RSpec.describe SupplejackApi::RequestMetric do
 
   describe '#summarize' do
 
-    let!(:appeared_in_searches_yesterday) { create_list(:request_metric, 5, date: Time.zone.yesterday) }
-    let!(:user_set_views_yesterday) { create_list(:request_metric, 5, metric: 'user_set_views', date: Time.zone.yesterday) }
-    let!(:source_clickthroughs_yesterday) { create_list(:request_metric, 5, metric: 'source_clickthroughs', date: Time.zone.yesterday) }
-
+    let!(:appeared_in_searches_yesterday) { create_list(:request_metric, 5, date: 1.day.ago.utc) }
+    let!(:user_set_views_yesterday) { create_list(:request_metric, 5, metric: 'user_set_views', date: 1.day.ago.utc) }
+    let!(:source_clickthroughs_yesterday) { create_list(:request_metric, 5, metric: 'source_clickthroughs', date: 1.day.ago.utc) }
 
     let!(:appeared_in_searches_today) { create_list(:request_metric, 5) }
     let!(:user_set_views_today) { create_list(:request_metric, 5, metric: 'user_set_views') }
@@ -39,15 +38,15 @@ RSpec.describe SupplejackApi::RequestMetric do
 
       expect(SupplejackApi::RecordMetric.count).to eq 8
 
-      yesterday_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: Time.zone.today)
-      yesterday_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: Time.zone.today)
-      yesterday_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: Time.zone.today)
-      yesterday_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: Time.zone.today)
+      yesterday_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: 1.day.ago.utc)
+      yesterday_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: 1.day.ago.utc)
+      yesterday_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: 1.day.ago.utc)
+      yesterday_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: 1.day.ago.utc)
 
-      today_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: Time.zone.today)
-      today_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: Time.zone.today)
-      today_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: Time.zone.today)
-      today_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: Time.zone.today)
+      today_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: Time.now.utc)
+      today_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: Time.now.utc)
+      today_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: Time.now.utc)
+      today_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: Time.now.utc)
 
       expect(yesterday_summed_1001.appeared_in_searches).to eq 5
       expect(yesterday_summed_289.appeared_in_searches).to eq 10

--- a/spec/models/supplejack_api/request_metric_spec.rb
+++ b/spec/models/supplejack_api/request_metric_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe SupplejackApi::RequestMetric do
+  describe '#attributes' do
+    let(:request_metric) { create(:request_metric) }
+
+    it 'has a date' do
+      expect(request_metric.date).not_to be nil
+    end
+
+    it 'has records' do
+      expect(request_metric.records).to eq [
+        { record_id: 1001, display_collection: 'TAPHUI' },
+        { record_id: 289, display_collection: 'Papers Past' },
+        { record_id: 289, display_collection: 'Papers Past' },
+        { record_id: 30, display_collection: 'TAPHUI' },
+        { record_id: 411, display_collection: 'National Library of New Zealand' }
+      ]
+    end
+
+    it 'has a metric' do
+      expect(request_metric.metric).to eq 'appeared_in_searches'
+    end
+  end
+
+  describe '#summarize' do
+
+    let!(:appeared_in_searches_yesterday) { create_list(:request_metric, 5, date: Time.zone.yesterday) }
+    let!(:user_set_views_yesterday) { create_list(:request_metric, 5, metric: 'user_set_views', date: Time.zone.yesterday) }
+    let!(:source_clickthroughs_yesterday) { create_list(:request_metric, 5, metric: 'source_clickthroughs', date: Time.zone.yesterday) }
+
+
+    let!(:appeared_in_searches_today) { create_list(:request_metric, 5) }
+    let!(:user_set_views_today) { create_list(:request_metric, 5, metric: 'user_set_views') }
+    let!(:source_clickthroughs_today) { create_list(:request_metric, 5, metric: 'source_clickthroughs') }
+
+    it 'summarizes request metrics and saves them into Mongo' do
+      SupplejackApi::RequestMetric.summarize
+
+      expect(SupplejackApi::RecordMetric.count).to eq 8
+
+      yesterday_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: Time.zone.today)
+      yesterday_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: Time.zone.today)
+      yesterday_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: Time.zone.today)
+      yesterday_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: Time.zone.today)
+
+      today_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: Time.zone.today)
+      today_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: Time.zone.today)
+      today_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: Time.zone.today)
+      today_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: Time.zone.today)
+
+      expect(yesterday_summed_1001.appeared_in_searches).to eq 5
+      expect(yesterday_summed_289.appeared_in_searches).to eq 10
+      expect(yesterday_summed_30.appeared_in_searches).to eq 5
+      expect(yesterday_summed_30.appeared_in_searches).to eq 5
+
+      expect(yesterday_summed_1001.user_set_views).to eq 5
+      expect(yesterday_summed_289.user_set_views).to eq 10
+      expect(yesterday_summed_30.user_set_views).to eq 5
+      expect(yesterday_summed_30.user_set_views).to eq 5
+
+      expect(yesterday_summed_1001.source_clickthroughs).to eq 5
+      expect(yesterday_summed_289.source_clickthroughs).to eq 10
+      expect(yesterday_summed_30.source_clickthroughs).to eq 5
+      expect(yesterday_summed_30.source_clickthroughs).to eq 5
+
+      expect(today_summed_1001.appeared_in_searches).to eq 5
+      expect(today_summed_289.appeared_in_searches).to eq 10
+      expect(today_summed_30.appeared_in_searches).to eq 5
+      expect(today_summed_30.appeared_in_searches).to eq 5
+
+      expect(today_summed_1001.user_set_views).to eq 5
+      expect(today_summed_289.user_set_views).to eq 10
+      expect(today_summed_30.user_set_views).to eq 5
+      expect(today_summed_30.user_set_views).to eq 5
+
+      expect(today_summed_1001.source_clickthroughs).to eq 5
+      expect(today_summed_289.source_clickthroughs).to eq 10
+      expect(today_summed_30.source_clickthroughs).to eq 5
+      expect(today_summed_30.source_clickthroughs).to eq 5
+
+      expect(SupplejackApi::RequestMetric.count).to eq 0
+    end
+  end
+end

--- a/spec/models/supplejack_api/top_metric_spec.rb
+++ b/spec/models/supplejack_api/top_metric_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupplejackApi::TopMetric do
 
   describe '#attributes' do
     it 'has a date' do
-      expect(top_metric.date).to eq Time.zone.today
+      expect(top_metric.date).to eq Time.zone.now.utc.to_date
     end
 
     it 'has a metric' do


### PR DESCRIPTION
**Acceptance Criteria**

- Create an initial step for capturing metrics about each request that does not involve a find query.
- Request documents will be summarised in the background hourly into existing RecordMetric models.
- Request documents include date, metric, display_collection, and record_id.
- Request documents are discarded by summarised hourly task.
- Ensure request collection cannot exceed 5GB, using Mongos Capped Collection.
- Ensure summary job can work regardless of when it has been run (encase of cron failure).
- Ensure that crushed request metrics work with the current RecordMetric schema. So we don't have to change existing work.

**Notes ***

Our estimation is that the request documents should be less than 120MB an hour.
We have verified that the previous slow down issue was caused by the find queries, through looking in New Relic.
We want to minimise the number of find queries required by the summarised task by processing requests in batches and summing the results, before committing them into Mongo.