### PR TITLE
AIRBRAKE TIDY UP FOR API

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -21,8 +21,8 @@ module SupplejackApi
         end
 
         @record.set_status(params[:required_fragments])
-        @record.fragments.map(&:save!)
         @record.save!
+        @record.fragments.map(&:save!)
         @record.unset_null_fields
 
         render json: { status: :success, record_id: @record.record_id }


### PR DESCRIPTION
fragments were being saved but had no record_id.  The exception was
being caught and sent to Airbrake, but had over 25000 occurrences this
month.

https://digitalnz.airbrake.io/projects/77906/groups/2185903626260917576?filters=%7B%22order%22:%22last_notice%22,%22resolved%22:%22any%22%7D&tab=overview
