### PR TITLE
Airbrake: lonely operator on solr error message that is just being logged out

### DIFF
--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -153,8 +153,9 @@ module SupplejackApi
     end
 
     def solr_error_message(exception)
+      status_code_string = RSolr::Error::Http::STATUS_CODES[exception.response&.[](:status).to_i]
       {
-        title: "#{exception.response[:status]} #{RSolr::Error::Http::STATUS_CODES[exception.response[:status].to_i]}",
+        title: "#{exception.response&.[](:status)} #{status_code_string}",
         body: exception.send(:parse_solr_error_response, exception.response[:body])
       }
     end


### PR DESCRIPTION
I usually don't approve of this style, but this hash is just being logged, nothing else.  

https://digitalnz.airbrake.io/projects/77906/groups/2196081476960069018?filters=%7B%22order%22:%22last_notice%22,%22resolved%22:%22any%22%7D&tab=notice-detail