### PR TITLE
ADD MISSING MONGO INDEXES TO THE CODEBASE: As a PO, I want all mongo indexes added in code, so that I do not lose them. 

### DIFF
--- a/app/models/supplejack_api/concept.rb
+++ b/app/models/supplejack_api/concept.rb
@@ -5,6 +5,8 @@ module SupplejackApi
     include Support::Concept::Storable
     include Support::Concept::Searchable
 
+    index concept_id: 1
+
     def self.build_context(fields)
       context = {}
       namespaces = []


### PR DESCRIPTION
**Acceptance Criteria**
- All Mongo indexes in use (in Production) are stored in code
- Indexes that are listed in the code but NOT currently built are removed
(so that they don't accidentally unnecessarily get built one day)
- No existing (already built) indexes are removed 
(because that is a bit slow and scary)




