### PR TITLE
IMPROVE HARVESTER RECORDS ENDPOINT PERFORMANCE: As a Harvester I want the harvester/records endpoint to work efficiently, so that my harvest is reliable and is not impacted by calls exceeding haproxy's timeout limit

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -120,13 +120,10 @@ module SupplejackApi
 
       def hints
         indexes = SupplejackApi.config.record_class.collection.indexes.as_json.map { |index| index['key'].keys }.flatten
-        hints_hash = {}
-        search_params.each do |search_key, _v|
+        search_params.keys.each_with_object({}) do |search_key, object|
           next unless indexes.include? search_key
-          hints_hash[search_key] = 1
+          object[search_key] = 1
         end
-
-        hints_hash
       end
     end
   end

--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -223,6 +223,14 @@ module SupplejackApi
           expect(res['meta']['page']).to be 1
           expect(res['meta']['total_pages']).to be 2
         end
+
+        it 'adds mongo index hints to the query' do
+          indexes = [{"v"=>1, "key"=>{"fragments.source_id"=>1}, "name"=>"fragments.source_id_1", "ns"=>"dnz_api_development.records"}]
+          SupplejackApi.config.record_class.stub_chain(:collection, :indexes, :as_json).and_return indexes
+          expect_any_instance_of(Mongoid::Criteria).to receive(:hint).with({"fragments.source_id"=>1})
+
+          get :index, params: { search: { 'fragments.source_id': records.first.source_id }, search_options: { page: 1 }, api_key: api_key }
+        end
       end
     end
 


### PR DESCRIPTION
**Acceptance Criteria**
- Improve performance of `harvester/records.json`, `GET` and `POST` requests. 
- Consider add index to `fragments.source_id` and `fragments.job_id`

**Notes**
- We perform 2 kinds of queries in this endpoint:
```
"search"=> "fragments.source_id"=>"a-source-id(eg. nlnzcat_alma)"}
```
```
"search"=> "fragments.job_id"=>"a-job-id(eg. 5b037f31147d7b1efb87ae9b)"}
```
- Here is a sample of a random query that took 11 secs (which is still quite a lot of time)
```
RestClient.get("#{ENV['API_HOST']}/harvester/records.json", params: {api_key: ENV['HARVESTER_API_KEY'], "search"=>{"fragments.source_id"=>"nlnzcat_alma"}, "search_options"=>{"page"=>"32"}})
```
```
{
        "inprog" : [
                {
                        "desc" : "conn279422",
                        "threadId" : "0xde75520",
                        "connectionId" : 279422,
                        "opid" : 73153559,
                        "active" : true,
                        "secs_running" : 11,
                        "microsecs_running" : NumberLong(11574784),
                        "op" : "query",
                        "ns" : "dnz_api_production.records",
                        "query" : {
                                "count" : "records",
                                "query" : {
                                        "fragments.source_id" : "nlnzcat_alma"
                                }
                        },
                        "planSummary" : "COUNT_SCAN { fragments.source_id: 1.0 }",
                        "client" : "192.122.171.221:37262",
                        "numYields" : 11989,
                        "locks" : {
                                "Global" : "r",
                                "Database" : "r",
                                "Collection" : "r"
                        },
                        "waitingForLock" : false,
                        "lockStats" : {
                                "Global" : {
                                        "acquireCount" : {
                                                "r" : NumberLong(23980)
                                        },
                                        "acquireWaitCount" : {
                                                "r" : NumberLong(64)
                                        },
                                        "timeAcquiringMicros" : {
                                                "r" : NumberLong(70090)
                                        }
                                },
                                "Database" : {
                                        "acquireCount" : {
                                                "r" : NumberLong(11990)
                                        }
                                },
                                "Collection" : {
                                        "acquireCount" : {
                                                "r" : NumberLong(11990)
                                        }
                                }
                        }
                }
        ]
}
```
- See attached some samples of requests that took longer than 50 seconds.
- BUIld index in background!!! ;]

**History**
This is a follow up story to fix 504 being returned by the API - It's being caused because HAProxy only wait for 50 seconds for a response from the Rails app, if it takes more than that HAProxy will return a 504.
