### PR TITLE
FIX SOURCE LINK CHECK 504 TIMEOUTS: As a PO I want the linkchecker to operate efficiently, so that the job gets done without timing out.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
 - 2.3.1
 cache: bundler
 bundler_args: --without production
-sudo: false
+sudo: required
 before_script:
   - cp spec/dummy/config/mongoid.travis.yml spec/dummy/config/mongoid.yml
   - echo 'Pacific/Auckland' | sudo tee /etc/timezone

--- a/spec/models/supplejack_api/source_spec.rb
+++ b/spec/models/supplejack_api/source_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 module SupplejackApi
   describe Source do
     let!(:source) { FactoryBot.create(:source, status: 'active') }
-  
+
     describe '#suppressed' do
       let!(:suppressed_source) { FactoryBot.create(:source, status: 'suppressed') }
-  
+
       it 'should return all the suppressed sources' do
         expect(Source.suppressed.to_a).to eq [suppressed_source]
       end
@@ -42,7 +42,24 @@ module SupplejackApi
         expect_any_instance_of(Array).to receive(:sample).with(4)
 
         source.random_records(4)
-      end      
+      end
+    end
+
+    describe '#hints' do
+      context 'has mongo indexes' do
+        it 'returns a hash of index hints ' do
+          indexes = [{'name'=>'fragments.job_id_1_status_1'}]
+          SupplejackApi.config.record_class.stub_chain(:collection, :indexes, :as_json).and_return indexes
+
+          expect(source.hints).to eq({ 'fragments.job_id' => 1, 'status' => 1 })
+        end
+      end
+
+      context 'has no mongo indexes' do
+        it 'returns an empty hash ' do
+          expect(source.hints).to eq({})
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Acceptance criteria**
- [`#random_records`](https://github.com/DigitalNZ/supplejack_api/blob/f5a50f4b060d97a42dcf5d31dd1089c73bd2661e/app/models/supplejack_api/source.rb#L23) method performs efficiently using Mongo's `hint()` method (as per https://www.pivotaltracker.com/story/show/158483753)
- SourceCheckWorker runs successfully every time it's triggered by crontab
- Advise/recommendations on other potential improvements to `#random_records`
(eg the `sample` link mentioned in the notes)


**Notes**
- at the moment [`#random_records`](https://github.com/DigitalNZ/supplejack_api/blob/f5a50f4b060d97a42dcf5d31dd1089c73bd2661e/app/models/supplejack_api/source.rb#L23) can take more than 50 secs to run which causes HAProxy to timeout and send a 504 back to the user
- Could this also be worth considering:
https://docs.mongodb.com/manual/reference/operator/aggregation/sample/
- Airbrake error: https://digitalnz.airbrake.io/projects/96483/groups/2130871330609704993?tab=notice-detail
- See attached a Gateway timeout returned from this URL above.

**History**
- This is a follow up story to fix 504 being returned by the API - It's being caused because HAProxy only wait for 50 seconds for a response from the Rails app, if it takes more than that HAProxy will return a 504.
