### PR TITLE
METEOR: Admin page is timing out

### DIFF
--- a/app/models/supplejack_api/user_set.rb
+++ b/app/models/supplejack_api/user_set.rb
@@ -109,7 +109,7 @@ module SupplejackApi
     # rubocop:enable Lint/UselessAssignment
 
     def self.all_public_sets
-      where(privacy: 'public', :name.ne => 'Favourites')
+      where(privacy: 'public', :name.ne => 'Favourites').order_by(updated_at: :desc).limit(2000)
     end
 
     def self.public_sets(options = {})


### PR DESCRIPTION
**Acceptance Criteria**
* Stop the dnz site from https://digitalnz.org/admin/moderations timing out with this error:
`The webpage at https://digitalnz.org/admin/moderations might be temporarily down or it may have moved permanently to a new web address.
ERR_SPDY_PROTOCOL_ERROR`