### PR TITLE
[timebox 8 hrs] SOLR/ZOOKEEPER INVESTIGATION: As a Systems Manager, I want to be confident that Solr will not fail, so that we don't have yet more outages as a result

### DIFF
--- a/app/models/supplejack_api/user_set.rb
+++ b/app/models/supplejack_api/user_set.rb
@@ -82,10 +82,6 @@ module SupplejackApi
       primary_fragment.subject = subjects
 
       record.save!
-
-      Sunspot.session = Sunspot::Rails.build_session
-      record.index
-      Sunspot.commit
     end
 
     # Force-capitalize only the first word of the set name

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -101,10 +101,6 @@ module SupplejackApi
       end
 
       describe '#reindex_if_changed' do
-        before do
-          allow(Sunspot).to receive(:commit).and_return("true")
-        end
-
         let(:record) { FactoryBot.create(:record_with_fragment) }
         let(:user_set) { FactoryBot.create(:user_set) }
         context 'an active user_set has a index-able field changed' do
@@ -112,7 +108,6 @@ module SupplejackApi
           before do
             allow(user_set).to receive(:record_status).and_return("active")
             allow(user_set).to receive(:record).and_return(record)
-            expect(record).to receive(:index)
           end
 
           it 'calls sunspot index if privacy field changed' do
@@ -170,17 +165,6 @@ module SupplejackApi
 
           it 'calls sunspot index if description field changed' do
             user_set.update_attribute(:description, 'A new description')
-          end
-        end
-
-        context 'an un-active user_set that is approved' do
-          before do
-            allow(user_set).to receive(:record).and_return(record)
-            expect(record).to receive(:index)
-          end
-
-          it 'calls sunspot index' do
-            user_set.update_attribute(:approved, true)
           end
         end
       end


### PR DESCRIPTION
**Changes**
- stop unnecessary solr commits on the user set save callback.  The index is updated without us having to force it.



**Acceptance Criteria**
- Make a good attempt to determine why Solr has been failing recently and identify ways to avoid/improve stability.

**Notes**
- [stack overflow](https://stackoverflow.com/questions/23743424/solr-issue-clusterstate-says-we-are-the-leader-but-locally-we-dont-think-so)
- Solr has failed a few times recently which has resulted in temporary outages. Most recent was this past weekend - see Slack #dev-all-dnz for timings (https://digitalnz.slack.com/archives/C02TAC9LH/p1531080490000107)
- Apparently Zookeeper is implicated - check Oliver to provide error messages.
  - `ClusterState says we are the leader, but locally we don't think so`
  -  `ClusterState says we are the leader, but locally we don't think so. Request came from null`
- Apparently Solr has been sending more alerts to Boost recently - see Oliver & Richard. Finding out when this started and what events it may have coincided with would be a good start.
- Oliver mentioned that it's hard to find the cause after the problem has been resolved (the first priority on production systems) - James suggested that, as a last resort and with proper management, pehaps it would be possible to engineer a similar situation in Staging and find potential root causes or, at least, observe processes that could be fixed/improved.
- James says ... recent System instability does seem to have strongly coincided with Mongo upgrade. So consider system resource availability in investigation.
- James also says ... I have a nagging suspicion about the stability of DNZ02 hardware. (We plan to do some work to confrim/dispell in upcoming patching.) So keep an eye out for DNZ02 triggering/being implicated.
- Dan says .. Havresters have noticed records making it into mongo but not into solr from harvests on the 9th July. I suspect the attached New Relic chart indicates an outage to solr where no records were indexed from 10am Sun to 9am Mon. (https://rpm.newrelic.com/accounts/93436/applications/70369857/solr_updates) I will arrange the harvesters to catch up  and re-run important harvests during this period.

