### PR TITLE
PLACEHOLDER ICONS ON HOMEPAGE: As a user I want to see the placeholder icons on featured stories on the homepage so that I get that improved experience on the homepage.

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -122,6 +122,7 @@ module SupplejackApi
       def hints
         indexes = SupplejackApi.config.record_class.collection.indexes.as_json.map { |index| index['key'].keys }.flatten
         search_params.keys.each_with_object({}) do |search_key, object|
+          next if search_key == 'record_id'
           next unless indexes.include? search_key
           object[search_key] = 1
         end

--- a/app/services/stories_api/v3/presenters/story.rb
+++ b/app/services/stories_api/v3/presenters/story.rb
@@ -29,6 +29,10 @@ module StoriesApi
           result[:number_of_items] = story.set_items.to_a.count { |item| item.type != 'text' }
           result[:creator] = story.user.name
 
+          cover_item = story.set_items.select { |set_item| set_item['meta']['is_cover'] == true }.first
+
+          result[:category] = cover_item['content']['category'].first if cover_item.present?
+
           if slim
             result[:record_ids] = story.set_items.sort_by(&:position).map do |item|
               { record_id: item.record_id, story_item_id: item._id.to_s }

--- a/app/services/stories_api/v3/presenters/story.rb
+++ b/app/services/stories_api/v3/presenters/story.rb
@@ -31,7 +31,7 @@ module StoriesApi
 
           cover_item = story.set_items.detect { |set_item| set_item['meta']['is_cover'] == true }
 
-          result[:category] = cover_item['content']['category'].first if cover_item.present?
+          result[:category] = cover_item['content']['category']&.first if cover_item.present?
 
           if slim
             result[:record_ids] = story.set_items.sort_by(&:position).map do |item|

--- a/app/services/stories_api/v3/presenters/story.rb
+++ b/app/services/stories_api/v3/presenters/story.rb
@@ -29,7 +29,7 @@ module StoriesApi
           result[:number_of_items] = story.set_items.to_a.count { |item| item.type != 'text' }
           result[:creator] = story.user.name
 
-          cover_item = story.set_items.select { |set_item| set_item['meta']['is_cover'] == true }.first
+          cover_item = story.set_items.detect { |set_item| set_item['meta']['is_cover'] == true }
 
           result[:category] = cover_item['content']['category'].first if cover_item.present?
 


### PR DESCRIPTION
Acceptance Criteria
=================

- placeholder icons display instead of text default for homepage featured stories.

Background
=================

This work was done on the search results page, but not implemented on the home page as well. The difference between these two though is that the search results page uses the records api and is in React, whereas the homepage uses the stories API and is in Rails. 

There was a small change on SJ Engine as well to provide the category field. 

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Builds Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)