### PR TITLE
RESPOND THE RIGHT ERROR CODES FOR SEARCH

### DIFF
--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -12,6 +12,7 @@ module SupplejackApi
     skip_before_action :authenticate_user!, only: %i[source status], raise: false
     before_action :set_concept_param, only: :index
     respond_to :json, :xml, :rss
+
     def index
       @search = SupplejackApi::RecordSearch.new(all_params)
       @search.request_url = request.original_url
@@ -36,10 +37,6 @@ module SupplejackApi
       else
         render request.format.to_sym => { errors: @search.errors }, status: :bad_request
       end
-    rescue RSolr::Error::Http => e
-      render request.format.to_sym => { errors: e }, status: :bad_request
-    rescue Sunspot::UnrecognizedFieldError => e
-      render request.format.to_sym => { errors: e.to_s }, status: :bad_request
     end
 
     def status
@@ -62,8 +59,6 @@ module SupplejackApi
         end
         format.rss { respond_with @record }
       end
-    rescue Mongoid::Errors::DocumentNotFound
-      render request.format.to_sym => { errors: "Record with ID #{params[:id]} was not found" }, status: :not_found
     end
 
     def multiple

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -352,10 +352,6 @@ module SupplejackApi
       self.errors << e
       Rails.logger.info self.errors
       sunspot = {}
-    rescue Timeout::Error, Errno::ECONNREFUSED, Errno::ECONNRESET => e
-      self.errors << 'Solr is temporarily unavailable please try again in a few seconds.'
-      Rails.logger.info e.message
-      sunspot = {}
     ensure
       sunspot
     end

--- a/app/models/supplejack_api/user_set.rb
+++ b/app/models/supplejack_api/user_set.rb
@@ -105,7 +105,7 @@ module SupplejackApi
     # rubocop:enable Lint/UselessAssignment
 
     def self.all_public_sets
-      where(privacy: 'public', :name.ne => 'Favourites').order_by(updated_at: :desc).limit(2000)
+      where(privacy: 'public', :name.ne => 'Favourites').order_by(updated_at: :desc)
     end
 
     def self.public_sets(options = {})

--- a/spec/models/supplejack_api/record_search_spec.rb
+++ b/spec/models/supplejack_api/record_search_spec.rb
@@ -56,15 +56,8 @@ module SupplejackApi
           allow(@sunspot_builder).to receive(:execute).and_raise(RSolr::Error::Http.new({}, {}))
           allow(@search).to receive(:solr_error_message) { 'Problem!' }
           @search.execute_solr_search
-          expect(@search.errors.first).to be_a RSolr::Error::Http
-        end
 
-        [Timeout::Error, Errno::ECONNREFUSED, Errno::ECONNRESET].each do |error_klass|
-          it 'adds a error message for a #{Timeout::Error} error' do
-            allow(@sunspot_builder).to receive(:execute).and_raise(error_klass)
-            expect(@search.execute_solr_search).to eq({})
-            expect(@search.errors.first).to eq 'Solr is temporarily unavailable please try again in a few seconds.'
-          end
+          expect(@search.errors.first).to be_a RSolr::Error::Http
         end
       end
 


### PR DESCRIPTION
Acceptance Criteria
=================
Error handling updated so that allows timeouts in the SJ Search to raise an exception rather than returns an empty search.

Solution
=================
This was to be done on the SJ client. But for the client to understand the difference between error codes i had to fix the api first. Before the API was only returning 400 for all type of errors. Moved 3 errors to applications controller and handling it globally. Delete irrelevant rescues.


Checklist
=================

- [ ] [ ] Pull Request should have a descriptive title
- [ ] [ ] Code is understandable without Dev
- [ ] [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] [ ] All new methods have a relevant spec