### PR TITLE
[timebox 4hrs] INVESTIGATE SOLR DEEP PAGING ISSUE: As Dan I want to understand what is causing the issue, so that we know how best to avoid/prevent/fix the issue

### DIFF
--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -113,7 +113,7 @@ module SupplejackApi
       self.class.max_values.each_key do |attribute|
         max_value = self.class.max_values[attribute]
         if @options[attribute].to_i > max_value
-          self.warnings << "The #{attribute} parameter can not exceed #{max_value}"
+          self.errors << "The #{attribute} parameter can not exceed #{max_value}"
         end
       end
 

--- a/spec/models/supplejack_api/search_spec.rb
+++ b/spec/models/supplejack_api/search_spec.rb
@@ -179,28 +179,28 @@ module SupplejackApi
         @search.options[:page] = 100_001
         @search.valid?
 
-        expect(@search.warnings).to include 'The page parameter can not exceed 100000'
+        expect(@search.errors).to include 'The page parameter can not exceed 100000'
       end
 
       it 'sets warning if per_page vale is greater than 100' do
         @search.options[:per_page] = 101
         @search.valid?
 
-        expect(@search.warnings).to include 'The per_page parameter can not exceed 100'
+        expect(@search.errors).to include 'The per_page parameter can not exceed 100'
       end
 
       it 'sets warning if facets_per_page vale is greater than 350' do
         @search.options[:facets_per_page] = 351
         @search.valid?
 
-        expect(@search.warnings).to include 'The facets_per_page parameter can not exceed 350'
+        expect(@search.errors).to include 'The facets_per_page parameter can not exceed 350'
       end
 
       it 'sets warning if facets_page vale is greater than 5000' do
         @search.options[:facets_page] = 5001
         @search.valid?
 
-        expect(@search.warnings).to include 'The facets_page parameter can not exceed 5000'
+        expect(@search.errors).to include 'The facets_page parameter can not exceed 5000'
       end
     end
 


### PR DESCRIPTION
Prevent deep pagination memory cut outs, by throwing a validation error.

Changing the api response from this:
![screen shot 2018-08-16 at 12 45 09 pm](https://user-images.githubusercontent.com/10747958/44181329-67c42500-a155-11e8-9229-2ab543228a25.png)

**to this:**

![screen shot 2018-08-16 at 12 47 41 pm](https://user-images.githubusercontent.com/10747958/44181336-714d8d00-a155-11e8-9c22-12bc538b1a3a.png)



**Acceptance Criteria**
- We understand what is going wrong with solr when the API hits the deep pagination issue
- Options recommended for avoiding/preventing/fixing issue
- Follow up stories drafted (if appropriate)

**Notes**
- Initially found when Monty (and Gus) were trying to page to the last page of the API (in order to create a natlib sitemap). This caused solr to fall over on dnz03 and dnz01 (also took a few goes to come back online)
- Staging does not have enough records to recreate the issue.
- If it comes down to it, the priority is to prevent things from breaking, rather than enabling deep pagination.

**Impacts**
- If anyone using our API pages too deeply they will bring the system down. Luckily know one knows this weakness.