### PR TITLE
Remove copying workers across in supplejack installation

### DIFF
--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -25,10 +25,6 @@ module SupplejackApi
         end
       end
 
-      def workers
-        directory 'app/workers'
-      end
-
       def initializers
         puts "\nInstalling initializers into config/initializers/"
 


### PR DESCRIPTION
These workers no longer exist within the engine spec/dummy directory. The `supplejack_api:install` generator crashes when it tries to copy the missing worker files which results in the rest of the installation fails.

Changes:
* Remove the `#workers` method