### PR TITLE
Fix for passing options to the serializer

### DIFF
--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -5,7 +5,7 @@ module SupplejackApi
   class Search
     def initialize(options = {})
       @options = options.dup
-      @options.merge!(
+      @options.reverse_merge!(
         facets: '',
         and: {},
         or: {},

--- a/app/serializers/supplejack_api/search_serializer.rb
+++ b/app/serializers/supplejack_api/search_serializer.rb
@@ -7,7 +7,7 @@ module SupplejackApi
     end
 
     attribute :results do
-      options = { fields: instance_options[:record_fields] }
+      options = { fields: instance_options[:record_fields], include: instance_options[:record_includes] }
       ActiveModelSerializers::SerializableResource.new(object.results, options)
     end
 

--- a/app/services/determine_available_fields.rb
+++ b/app/services/determine_available_fields.rb
@@ -10,7 +10,6 @@ class DetermineAvailableFields
 
   def call
     groups = (options[:groups] & RecordSchema.groups.keys) || []
-
     fields = RecordSchema.groups.values_at(*groups).flat_map(&:fields).uniq
 
     fields += options[:fields] if options[:fields].present?

--- a/spec/models/supplejack_api/search_spec.rb
+++ b/spec/models/supplejack_api/search_spec.rb
@@ -1,5 +1,3 @@
-
-
 require 'spec_helper'
 
 module SupplejackApi
@@ -15,6 +13,33 @@ module SupplejackApi
     describe '#initialize' do
       it 'sets the options' do
         expect(@search).to respond_to :options
+      end
+
+      it 'reverse_merges default options without replacing requested options' do
+        expect(Search.new(fields: 'title').options[:fields]).to eq 'title'
+      end
+
+      it 'uses sensible defaults when no options are provided' do
+        default_options =
+        {
+          facets: '',
+          and: {},
+          or: {},
+          without: {},
+          page: 1,
+          per_page: 20,
+          record_type: 0,
+          facets_per_page: 10,
+          facets_page: 1,
+          sort: nil,
+          direction: 'desc',
+          exclude_filters_from_facets: false,
+          fields: 'default',
+          facet_query: {},
+          debug: nil
+        }
+
+        expect(Search.new.options).to eq default_options
       end
     end
 


### PR DESCRIPTION
Problem discovered where fields passed in the URL were being ignored, simple mistake of merge over reverse_merge. 