### PR TITLE
TOP RECORDS BY COLLECTION

### DIFF
--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -5,18 +5,19 @@ module SupplejackApi
   class RecordMetric
     include Mongoid::Document
 
-    field :date,                            type: Date,    default: Time.zone.now.beginning_of_day
-    field :record_id,                       type: Integer
-    field :page_views,                      type: Integer, default: 0
-    field :user_set_views,                  type: Integer, default: 0
-    field :display_collection,              type: String
-    field :user_story_views,                type: Integer, default: 0
-    field :added_to_user_sets,              type: Integer, default: 0
-    field :source_clickthroughs,            type: Integer, default: 0
-    field :appeared_in_searches,            type: Integer, default: 0
-    field :added_to_user_stories,           type: Integer, default: 0
-    field :processed_by_collection_metrics, type: Boolean, default: false
-    field :processed_by_top_metrics,        type: Boolean, default: false
+    field :date,                                type: Date,    default: Time.zone.now.beginning_of_day
+    field :record_id,                           type: Integer
+    field :page_views,                          type: Integer, default: 0
+    field :user_set_views,                      type: Integer, default: 0
+    field :display_collection,                  type: String
+    field :user_story_views,                    type: Integer, default: 0
+    field :added_to_user_sets,                  type: Integer, default: 0
+    field :source_clickthroughs,                type: Integer, default: 0
+    field :appeared_in_searches,                type: Integer, default: 0
+    field :added_to_user_stories,               type: Integer, default: 0
+    field :processed_by_collection_metrics,     type: Boolean, default: false
+    field :processed_by_top_metrics,            type: Boolean, default: false
+    field :processed_by_top_collection_metrics, type: Boolean, default: false
 
     validates :record_id, presence: true
     validates :record_id, uniqueness: { scope: :date }

--- a/app/models/supplejack_api/top_collection_metric.rb
+++ b/app/models/supplejack_api/top_collection_metric.rb
@@ -78,7 +78,7 @@ module SupplejackApi
 
       query = { :date.lt => Time.zone.now.beginning_of_day, processed_by_top_collection_metrics: false }
       SupplejackApi::RecordMetric.where(query)
-                                 .map(&:display_collection).uniq.compact
+                                 .map(&:display_collection).uniq
     end
 
     def self.calculate_results(record_metrics, metric)

--- a/app/models/supplejack_api/top_collection_metric.rb
+++ b/app/models/supplejack_api/top_collection_metric.rb
@@ -81,6 +81,9 @@ module SupplejackApi
 
         top_collection_metric.update(results: merged_results)
       end
+
+      METRICS_LOGGER.info "Updated Top Collection Metric: #{top_collection_metric.inspect}"
+      top_collection_metric
     end
 
     def self.find_or_create_top_collection_metric(date, metric, display_collection)
@@ -103,6 +106,7 @@ module SupplejackApi
     end
 
     def self.stamp_record_metrics(date)
+      METRICS_LOGGER.info "Stamping Record Metrics for date: #{date}"
       SupplejackApi::RecordMetric.where(date: date).update_all(processed_by_top_collection_metrics: true)
     end
   end

--- a/app/models/supplejack_api/top_collection_metric.rb
+++ b/app/models/supplejack_api/top_collection_metric.rb
@@ -1,0 +1,75 @@
+module SupplejackApi
+  # app/models/supplejack_api/top_collection_metric.rb
+  class TopCollectionMetric
+    include Mongoid::Document
+
+    METRICS = %i[
+      page_views
+      user_set_views
+      user_story_views
+      added_to_user_sets
+      source_clickthroughs
+      appeared_in_searches
+      added_to_user_stories
+    ].freeze
+
+
+    field :d, as: :date,               type: Date, default: Time.current.utc
+    field :m, as: :metric,             type: String
+    field :r, as: :results,            type: Hash
+    field :c, as: :display_collection, type: String
+
+    validates :date, presence: true
+    validates :metric, presence: true
+    validates :metric, uniqueness: { :scope => [:date, :display_collection] }
+
+    def self.spawn
+      return unless SupplejackApi.config.log_metrics == true
+
+      display_collections = SupplejackApi::RecordMetric.where(:date.lt => Time.zone.now.beginning_of_day, processed_by_top_collection_metrics: false)
+                                                       .map(&:display_collection).uniq.compact
+
+      dates = SupplejackApi::RecordMetric.where(:date.lt => Time.zone.now.beginning_of_day).map(&:date).uniq
+
+      dates.each do |date|
+        METRICS.each do |metric|
+          display_collections.each do |dc|
+            record_metrics = record_metrics_to_be_processed(date, metric, dc)
+
+            results = record_metrics.each_with_object({}) do |record, hash|
+              hash[record.record_id.to_s] = record.send(metric)
+            end
+
+            top_collection_metric = find_or_create_by(
+              date: date,
+              metric: metric,
+              display_collection: dc
+            )
+
+            if top_collection_metric.results.blank?
+              top_collection_metric.update(results: results)
+            else
+              merged_results = top_collection_metric.results.merge(results) { |_key, a, b| a + b }
+              merged_results = merged_results.sort_by { |_k, v| -v }.first(200).to_h
+
+              top_collection_metric.update(results: merged_results)
+            end
+          end
+        end
+        stamp_record_metrics(date)
+      end
+    end
+
+    def self.record_metrics_to_be_processed(date, metric, display_collection)
+      SupplejackApi::RecordMetric.where(
+        date: date,
+        display_collection: display_collection,
+        :processed_by_top_collection_metrics.in => [nil, '', false]
+      ).order_by(metric => 'desc').limit(200)
+    end
+
+    def self.stamp_record_metrics(date)
+      SupplejackApi::RecordMetric.where(date: date).update_all(processed_by_top_collection_metrics: true)
+    end
+  end
+end

--- a/app/models/supplejack_api/top_collection_metric.rb
+++ b/app/models/supplejack_api/top_collection_metric.rb
@@ -30,15 +30,11 @@ module SupplejackApi
       metrics = []
 
       dates.each do |date|
-
         display_collections(date).each do |dc|
-
           METRICS.each do |metric|
-
             record_metrics = record_metrics_to_be_processed(date, metric, dc)
 
             results = calculate_results(record_metrics, metric)
-
 
             # If there are no results for a metric, date, and display collection
             # Skip to the next metric
@@ -56,13 +52,11 @@ module SupplejackApi
     end
 
     def self.dates
-
       # query = { :date.lt => Time.zone.now.beginning_of_day }
       SupplejackApi::RecordMetric.all.map(&:date).uniq
     end
 
     def self.display_collections(date)
-
       SupplejackApi::RecordMetric.where(
         date: date,
         :processed_by_top_collection_metrics.in => [nil, '', false]

--- a/spec/factories/record_metric.rb
+++ b/spec/factories/record_metric.rb
@@ -2,6 +2,7 @@ module SupplejackApi
   FactoryBot.define do
     factory :record_metric, class: SupplejackApi::RecordMetric do
       sequence(:record_id)
+      display_collection 'Laramie'
     end
   end
 end

--- a/spec/factories/supplejack_api_top_collection_metrics.rb
+++ b/spec/factories/supplejack_api_top_collection_metrics.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :supplejack_api_top_collection_metric, class: 'SupplejackApi::TopCollectionMetric' do
-    
-  end
-end

--- a/spec/factories/supplejack_api_top_collection_metrics.rb
+++ b/spec/factories/supplejack_api_top_collection_metrics.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :supplejack_api_top_collection_metric, class: 'SupplejackApi::TopCollectionMetric' do
+    
+  end
+end

--- a/spec/factories/top_collection_metric.rb
+++ b/spec/factories/top_collection_metric.rb
@@ -1,9 +1,3 @@
-# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3.
-# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
-#
-# Supplejack was created by DigitalNZ at the National Library of NZ and
-# the Department of Internal Affairs. http://digitalnz.org/supplejack
 
 module SupplejackApi
   FactoryBot.define do

--- a/spec/factories/top_collection_metric.rb
+++ b/spec/factories/top_collection_metric.rb
@@ -1,0 +1,14 @@
+# The majority of the Supplejack API code is Crown copyright (C) 2014, New Zealand Government,
+# and is licensed under the GNU General Public License, version 3.
+# One component is a third party component. See https://github.com/DigitalNZ/supplejack_api for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and
+# the Department of Internal Affairs. http://digitalnz.org/supplejack
+
+module SupplejackApi
+  FactoryBot.define do
+    factory :top_collection_metric, class: SupplejackApi::TopCollectionMetric do
+      metric 'appeared_in_searches'
+    end
+  end
+end

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SupplejackApi::RecordMetric do
       expect(record_metric.added_to_user_stories).to eq 0
     end
 
-    it 'has processed_by_top_collection_metrics' do
+    it 'has default false processed_by_top_collection_metrics flag' do
       expect(record_metric.processed_by_top_collection_metrics).to be false
     end
   end

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe SupplejackApi::RecordMetric do
     it 'has added_to_user_stories' do
       expect(record_metric.added_to_user_stories).to eq 0
     end
+
+    it 'has processed_by_top_collection_metrics' do
+      expect(record_metric.processed_by_top_collection_metrics).to be false
+    end
   end
 
   describe '#validations' do

--- a/spec/models/supplejack_api/top_collection_metric_spec.rb
+++ b/spec/models/supplejack_api/top_collection_metric_spec.rb
@@ -26,19 +26,7 @@ RSpec.describe SupplejackApi::TopCollectionMetric, type: :model do
     let!(:metric_group) { create_list(:record_metric, 250, date: Time.zone.yesterday, page_views: 1, display_collection: 'Laramie') }
     let!(:yesterdays_metric_group) { create_list(:record_metric, 5, date: Time.zone.yesterday - 1.day, page_views: 2, display_collection: 'Laramie') }
 
-    context 'metrics logging is disabled' do
-      it 'returns nil' do
-        allow(SupplejackApi).to receive_message_chain(:config, :log_metrics).and_return(false)
-
-        expect(described_class.spawn).to eq nil
-      end
-    end
-
     before do
-      # Stub Metrics logger
-      allow(Logger).to receive(:new).and_return(nil)
-      allow(SupplejackApi::TopCollectionMetric::METRICS_LOGGER).to receive(:info).and_return(nil)
-
       described_class::METRICS.each do |metric|
         create(:record_metric, date: Time.zone.yesterday, metric.to_sym => 1, display_collection: 'Laramie')
       end

--- a/spec/models/supplejack_api/top_collection_metric_spec.rb
+++ b/spec/models/supplejack_api/top_collection_metric_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 RSpec.describe SupplejackApi::TopCollectionMetric, type: :model do
+  let(:top_collection_metric) { create(:top_collection_metric, results: { 1 => 200, 2 => 150 }) }
+
+  describe '#attributes' do
+    it 'has a date' do
+      expect(top_collection_metric.date).to eq Time.zone.now.utc.to_date
+    end
+
+    it 'has a metric' do
+      expect(top_collection_metric.metric).to eq 'appeared_in_searches'
+    end
+
+    it 'has results' do
+      results = { 1 => 200, 2 => 150 }
+      expect(top_collection_metric.results).to eq results
+    end
+  end
 
   describe '::spawn' do
     let!(:metric_one)   { create(:record_metric, appeared_in_searches: 1, date: Time.zone.yesterday, display_collection: 'Gotta collect them all!') }
@@ -33,6 +49,12 @@ RSpec.describe SupplejackApi::TopCollectionMetric, type: :model do
         display_collections.each do |dc|
           expect(SupplejackApi::TopCollectionMetric.where(metric: metric, display_collection: dc)).to exist
         end
+      end
+    end
+
+    it 'stamps all processed RecordMetric records :processed_by_top_collection_metrics flag as true' do
+      SupplejackApi::RecordMetric.all.each do |record_metric|
+        expect(record_metric.processed_by_top_collection_metrics).to be true
       end
     end
 

--- a/spec/models/supplejack_api/top_collection_metric_spec.rb
+++ b/spec/models/supplejack_api/top_collection_metric_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe SupplejackApi::TopCollectionMetric, type: :model do
+
+  describe '::spawn' do
+    let!(:metric_one)   { create(:record_metric, appeared_in_searches: 1, date: Time.zone.yesterday, display_collection: 'Gotta collect them all!') }
+    let!(:metric_two)   { create(:record_metric, appeared_in_searches: 2, date: Time.zone.yesterday, display_collection: 'Supplejack LTD') }
+    let!(:metric_three) { create(:record_metric, appeared_in_searches: 3, date: Time.zone.yesterday, display_collection: 'Collecty McCollectyface') }
+
+    let!(:metric_group) { create_list(:record_metric, 250, date: Time.zone.yesterday, page_views: 1, display_collection: 'Laramie') }
+    let!(:yesterdays_metric_group) { create_list(:record_metric, 5, date: Time.zone.yesterday - 1.day, page_views: 2, display_collection: 'Laramie') }
+
+    context 'metrics logging is disabled' do
+      it 'returns nil' do
+        allow(SupplejackApi).to receive_message_chain(:config, :log_metrics).and_return(false)
+
+        expect(described_class.spawn).to eq nil
+      end
+    end
+
+    before do
+      create(:record_metric, date: Time.zone.yesterday, appeared_in_searches: 1, display_collection: 'Laramie')
+      create(:record_metric, date: Time.zone.yesterday, appeared_in_searches: 2, display_collection: 'Laramie')
+      create(:record_metric, date: Time.zone.yesterday, appeared_in_searches: 3, display_collection: 'Laramie')
+      SupplejackApi::TopCollectionMetric.spawn
+    end
+
+    it 'creates TopCollectionMetrics for each metric AND collection' do
+      metrics = ['added_to_user_sets', 'added_to_user_stories', 'appeared_in_searches', 'page_views', 'source_clickthroughs', 'user_set_views', 'user_story_views']
+      display_collections = described_class.all.map(&:display_collection)
+
+      metrics.each do |metric|
+        display_collections.each do |dc|
+          expect(SupplejackApi::TopCollectionMetric.where(metric: metric, display_collection: dc)).to exist
+        end
+      end
+    end
+
+    it 'only takes the top 200 records for each metric AND collection' do
+      expect(SupplejackApi::TopCollectionMetric.find_by(date: Time.zone.yesterday, metric: 'page_views', display_collection: 'Laramie').results.keys.count).to eq 200
+    end
+
+    it 'orders the results from highest to lowest' do
+      expect(SupplejackApi::TopCollectionMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches', display_collection: 'Laramie').results.values.first).to eq 3
+    end
+
+    it 'spawns metrics across multiple days' do
+      expect(SupplejackApi::TopCollectionMetric.find_by(date: Time.zone.yesterday - 1.day, metric: 'page_views', display_collection: 'Laramie').results.keys.count).to eq 5
+    end
+
+    it 'sets RecordMetrics :processed_by_top_collection_metrics flag to `true`' do
+      [metric_one, metric_two, metric_three].each do |metric|
+        expect(metric.reload.processed_by_top_collection_metrics).to be true
+      end
+    end
+
+    it 'appends new top collection metrics that creep in after the initial run' do
+      SupplejackApi::RecordMetric.destroy_all
+
+      create(:record_metric, appeared_in_searches: 1, date: Time.zone.yesterday, record_id: metric_three.record_id, display_collection: 'Laramie')
+      create(:record_metric, appeared_in_searches: 1, date: Time.zone.yesterday, display_collection: 'Laramie')
+
+      SupplejackApi::TopCollectionMetric.spawn
+
+      expect(SupplejackApi::TopCollectionMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches', display_collection: 'Laramie').results.values.first).to eq 3
+      expect(SupplejackApi::TopCollectionMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches', display_collection: 'Laramie'))
+      expect(SupplejackApi::TopCollectionMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches', display_collection: 'Laramie').results.keys.count).to eq 200
+    end
+  end
+end

--- a/spec/models/supplejack_api/top_collection_metric_spec.rb
+++ b/spec/models/supplejack_api/top_collection_metric_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe SupplejackApi::TopCollectionMetric, type: :model do
     end
 
     before do
+      # Stub Metrics logger
+      allow(Logger).to receive(:new).and_return(nil)
+      allow(SupplejackApi::TopCollectionMetric::METRICS_LOGGER).to receive(:info).and_return(nil)
+
       create(:record_metric, date: Time.zone.yesterday, appeared_in_searches: 1, display_collection: 'Laramie')
       create(:record_metric, date: Time.zone.yesterday, appeared_in_searches: 2, display_collection: 'Laramie')
       create(:record_metric, date: Time.zone.yesterday, appeared_in_searches: 3, display_collection: 'Laramie')

--- a/spec/models/supplejack_api/top_metric_spec.rb
+++ b/spec/models/supplejack_api/top_metric_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SupplejackApi::TopMetric do
-  let(:top_metric) { create(:top_metric, results: { 1 => 200, 2 => 150 }) }
+  let(:top_metric) { create(:top_metric, results: { 1 => 200, 2 => 150 }, date: Time.zone.now.utc.to_date) }
 
   describe '#attributes' do
     it 'has a date' do


### PR DESCRIPTION
**Acceptance Criteria**

- Top 200 records **by collection** are generated  for each metric listed below:
```
"page_views"
"user_set_views"
"user_story_views"
"source_clickthroughs"
"appeared_in_searches"
"added_to_user_stories"
```
- Top 200 collection metrics are generated daily.
- Crushing process can be run **anytime** during the day without compromising the data.