### PR TITLE
METEOR: SJ not activating previously deleted records

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -13,11 +13,12 @@ module SupplejackApi
         # In the long run this condition shouldn't be here.
         # It's because the data_handler interfaces are using update_from_harvest,
         # and clear_attributes that I can't factor it back in.
+
         if params[:record][:priority] && params[:record][:priority].to_i.nonzero?
           @record.create_or_update_fragment(record_params)
         else
           @record.clear_attributes
-          @record.update_from_harvest(record_params)
+          @record.update_from_harvest!(record_params)
         end
 
         @record.set_status(params[:required_fragments])

--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -52,7 +52,7 @@ module SupplejackApi
         end
 
         it "saves the record" do
-          expect(record).to receive(:save)
+          expect(record).to receive(:save).twice
           post :create, params: { record: {"internal_identifier" => "1234"}, api_key: api_key }
         end
 


### PR DESCRIPTION
**Acceptance Criteria**

- Harvesting fresh metadata over the top of a previously deleted record should (as well as updating the fragment with new metadata) set status to 'active'