### PR TITLE
Fix full and flush bug

### DIFF
--- a/app/models/supplejack_api/support/harvestable.rb
+++ b/app/models/supplejack_api/support/harvestable.rb
@@ -87,8 +87,6 @@ module SupplejackApi
           start = 0
           chunk_size = 10_000
 
-          Sunspot.session = Sunspot::Rails.build_session unless Rails.env.test?
-
           while start < total
             records = cursor.limit(chunk_size).skip(start)
             Sunspot.remove(records)

--- a/app/models/supplejack_api/support/harvestable.rb
+++ b/app/models/supplejack_api/support/harvestable.rb
@@ -85,7 +85,7 @@ module SupplejackApi
           cursor = deleted.where('fragments.source_id': source_id)
           total = cursor.count
           start = 0
-          chunk_size = 10_000
+          chunk_size = 500
 
           while start < total
             records = cursor.limit(chunk_size).skip(start)

--- a/app/models/supplejack_api/support/harvestable.rb
+++ b/app/models/supplejack_api/support/harvestable.rb
@@ -72,32 +72,6 @@ module SupplejackApi
           identifier = identifier.first if identifier.is_a?(Array)
           find_or_initialize_by(internal_identifier: identifier)
         end
-
-        def flush_old_records(source_id, job_id)
-          Rails.logger.info "FULL-AND-FLUSH: source_id: #{source_id} -- job_id: #{job_id}"
-          where(
-            :'fragments.source_id' => source_id,
-            :'fragments.job_id'.ne => job_id,
-            :status.in => %w[active supressed],
-            'fragments.priority': 0
-          ).update_all(status: 'deleted', updated_at: Time.now,
-                       '$set': { 'fragments.$.job_id' => job_id })
-
-          cursor = deleted.where('fragments.source_id': source_id)
-          total = cursor.count
-          start = 0
-          chunk_size = 500
-
-          # Use Redis queue to delete records
-          Sunspot.session = Sunspot::SidekiqSessionProxy.new(Sunspot.session) unless Rails.env.test?
-
-          while start < total
-            records = cursor.limit(chunk_size).skip(start)
-            Rails.logger.info "FULL-AND-FLUSH: Removing #{start}/#{records.count} records."
-            Sunspot.remove(records)
-            start += chunk_size
-          end
-        end
       end
     end
   end

--- a/app/models/supplejack_api/support/harvestable.rb
+++ b/app/models/supplejack_api/support/harvestable.rb
@@ -90,7 +90,7 @@ module SupplejackApi
 
           while start < total
             records = cursor.limit(chunk_size).skip(start)
-            Rails.logger.info "Full and Flush - Removing #{records.count} records."
+            Rails.logger.info "Full and Flush - Removing #{start}/#{records.count} records."
             Sunspot.remove(records)
             start += chunk_size
           end

--- a/app/models/supplejack_api/support/harvestable.rb
+++ b/app/models/supplejack_api/support/harvestable.rb
@@ -74,7 +74,7 @@ module SupplejackApi
         end
 
         def flush_old_records(source_id, job_id)
-          Rails.logger.info "Flushing old records... source_id: #{source_id} -- job_id: #{job_id}"
+          Rails.logger.info "FULL-AND-FLUSH: source_id: #{source_id} -- job_id: #{job_id}"
           where(
             :'fragments.source_id' => source_id,
             :'fragments.job_id'.ne => job_id,
@@ -93,7 +93,7 @@ module SupplejackApi
 
           while start < total
             records = cursor.limit(chunk_size).skip(start)
-            Rails.logger.info "Full and Flush - Removing #{start}/#{records.count} records."
+            Rails.logger.info "FULL-AND-FLUSH: Removing #{start}/#{records.count} records."
             Sunspot.remove(records)
             start += chunk_size
           end

--- a/app/models/supplejack_api/support/harvestable.rb
+++ b/app/models/supplejack_api/support/harvestable.rb
@@ -74,6 +74,7 @@ module SupplejackApi
         end
 
         def flush_old_records(source_id, job_id)
+          Rails.logger.info "Flushing old records... source_id: #{source_id} -- job_id: #{job_id}"
           where(
             :'fragments.source_id' => source_id,
             :'fragments.job_id'.ne => job_id,
@@ -89,6 +90,7 @@ module SupplejackApi
 
           while start < total
             records = cursor.limit(chunk_size).skip(start)
+            Rails.logger.info "Full and Flush - Removing #{record.count} records."
             Sunspot.remove(records)
             start += chunk_size
           end

--- a/app/models/supplejack_api/support/harvestable.rb
+++ b/app/models/supplejack_api/support/harvestable.rb
@@ -90,7 +90,7 @@ module SupplejackApi
 
           while start < total
             records = cursor.limit(chunk_size).skip(start)
-            Rails.logger.info "Full and Flush - Removing #{record.count} records."
+            Rails.logger.info "Full and Flush - Removing #{records.count} records."
             Sunspot.remove(records)
             start += chunk_size
           end

--- a/app/models/supplejack_api/support/harvestable.rb
+++ b/app/models/supplejack_api/support/harvestable.rb
@@ -88,6 +88,9 @@ module SupplejackApi
           start = 0
           chunk_size = 500
 
+          # Use Redis queue to delete records
+          Sunspot.session = Sunspot::SidekiqSessionProxy.new(Sunspot.session) unless Rails.env.test?
+
           while start < total
             records = cursor.limit(chunk_size).skip(start)
             Rails.logger.info "Full and Flush - Removing #{start}/#{records.count} records."

--- a/app/models/supplejack_api/user_set.rb
+++ b/app/models/supplejack_api/user_set.rb
@@ -81,7 +81,8 @@ module SupplejackApi
       primary_fragment.description = description
       primary_fragment.subject = subjects
 
-      # FIXME: This class variable should not be set here
+      # FIXME: Overriding the session class variable to push records straight to solr.
+      # This will be removed in the future when we move to AWS
       Sunspot.session = Sunspot::Rails.build_session unless Rails.env.test?
       record.index
 

--- a/app/models/supplejack_api/user_set.rb
+++ b/app/models/supplejack_api/user_set.rb
@@ -85,6 +85,7 @@ module SupplejackApi
       # This will be removed in the future when we move to AWS
       Sunspot.session = Sunspot::Rails.build_session unless Rails.env.test?
       record.index
+      Sunspot.session = Sunspot::SidekiqSessionProxy.new(Sunspot.session) unless Rails.env.test?
 
       record.save!
     end

--- a/app/models/supplejack_api/user_set.rb
+++ b/app/models/supplejack_api/user_set.rb
@@ -81,6 +81,7 @@ module SupplejackApi
       primary_fragment.description = description
       primary_fragment.subject = subjects
 
+      # FIXME: This class variable should not be set here
       Sunspot.session = Sunspot::Rails.build_session unless Rails.env.test?
       record.index
 

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -10,7 +10,7 @@ class BatchIndexRecords
   end
 
   def call
-    Rails.logger.info "BatchIndexRecords - INDEXING: #{records} records"
+    Rails.logger.info "BatchIndexRecords - INDEXING: #{records.class} #{records.selector} #{records.options}"
     begin
       Sunspot.index(records)
     rescue StandardError

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -26,7 +26,7 @@ class BatchIndexRecords
         Rails.logger.info "BatchIndexRecords - INDEXING: #{record}"
         Sunspot.index record
       rescue StandardError => exception
-        Rails.logger.error "BatchIndexRecords - Failed to index record: #{record.inspect} with exception: #{exception.message}"
+        Rails.logger.error "BatchIndexRecords - Failed to index: #{record.inspect} - #{exception.message}"
       end
     end
   end

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -10,12 +10,9 @@ class BatchIndexRecords
   end
 
   def call
-    Rails.logger.info "BatchIndexRecords - INDEXING: #{records.class} #{records.selector} #{records.options}"
-    begin
-      Sunspot.index(records)
-    rescue StandardError
-      retry_index_records(records)
-    end
+    Sunspot.index(records)
+  rescue StandardError
+    retry_index_records(records)
   end
 
   private

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -10,7 +10,7 @@ class BatchIndexRecords
   end
 
   def call
-    Rails.logger.info "BatchIndexRecords - INDEXING: #{records.count} records"
+    Rails.logger.info "BatchIndexRecords - INDEXING: #{records} records"
     begin
       Sunspot.index(records)
     rescue StandardError

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class BatchIndexRecords
+  attr_reader :records
+
+  def initialize(records)
+    Sunspot.session = Sunspot::Rails.build_session
+
+    @records = records
+  end
+
+  def call
+    Rails.logger.info "INDEXING: #{records_to_index.count} records"
+    begin
+      Sunspot.index(records)
+    rescue StandardError
+      retry_index_records(records)
+    end
+  end
+
+  private
+
+  # Call Sunspot index in the array provided, if failure,
+  # retry each record individually to be indexed and log errors
+  def retry_index_records(records)
+    Rails.logger.info 'BatchIndexRecords - INDEXING batch has raised an exception - retrying individual records'
+    records.each do |record|
+      begin
+        Rails.logger.info "BatchIndexRecords - INDEXING: #{record}"
+        Sunspot.index record
+      rescue StandardError => exception
+        Rails.logger.error "BatchIndexRecords - Failed to index record: #{record.inspect} with exception: #{exception.message}"
+      end
+    end
+  end
+end

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -10,7 +10,7 @@ class BatchIndexRecords
   end
 
   def call
-    Rails.logger.info "INDEXING: #{records_to_index.count} records"
+    Rails.logger.info "BatchIndexRecords - INDEXING: #{records.count} records"
     begin
       Sunspot.index(records)
     rescue StandardError

--- a/app/services/batch_remove_from_index_records.rb
+++ b/app/services/batch_remove_from_index_records.rb
@@ -10,7 +10,7 @@ class BatchRemoveFromIndexRecords
   end
 
   def call
-    Rails.logger.info "UN-INDEXING: #{records_to_remove.count} records"
+    Rails.logger.info "BatchRemoveFromIndex - UN-INDEXING: #{records.count} records"
     begin
       Sunspot.remove(records)
     rescue StandardError

--- a/app/services/batch_remove_from_index_records.rb
+++ b/app/services/batch_remove_from_index_records.rb
@@ -10,12 +10,9 @@ class BatchRemoveFromIndexRecords
   end
 
   def call
-    Rails.logger.info "BatchRemoveFromIndex - UN-INDEXING: #{records.class} #{records.selector} #{records.options}"
-    begin
-      Sunspot.remove(records)
-    rescue StandardError
-      retry_remove_records(records)
-    end
+    Sunspot.remove(records)
+  rescue StandardError
+    retry_remove_records(records)
   end
 
   private

--- a/app/services/batch_remove_from_index_records.rb
+++ b/app/services/batch_remove_from_index_records.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class BatchRemoveFromIndexRecords
+  attr_reader :records
+
+  def initialize(records)
+    Sunspot.session = Sunspot::Rails.build_session
+
+    @records = records
+  end
+
+  def call
+    Rails.logger.info "UN-INDEXING: #{records_to_remove.count} records"
+    begin
+      Sunspot.remove(records)
+    rescue StandardError
+      retry_remove_records(records)
+    end
+  end
+
+  private
+
+  # Call Sunspot remove in the array provided, if failure,
+  # retry each record individually to be removed and log errors
+  def retry_remove_records(records)
+    Rails.logger.info 'BatchRemoveFromIndex - REMOVE INDEX batch has raised an exception - retrying individual records'
+    records.each do |record|
+      begin
+        Rails.logger.info "BatchRemoveFromIndex - REMOVE INDEX: #{record}"
+        Sunspot.remove record
+      rescue StandardError => exception
+        Rails.logger.error "BatchRemoveFromIndex - Failed to remove index record: #{record.inspect} with exception: #{exception.message}"
+      end
+    end
+  end
+end

--- a/app/services/batch_remove_from_index_records.rb
+++ b/app/services/batch_remove_from_index_records.rb
@@ -10,7 +10,7 @@ class BatchRemoveFromIndexRecords
   end
 
   def call
-    Rails.logger.info "BatchRemoveFromIndex - UN-INDEXING: #{records.count} records"
+    Rails.logger.info "BatchRemoveFromIndex - UN-INDEXING: #{records} records"
     begin
       Sunspot.remove(records)
     rescue StandardError

--- a/app/services/batch_remove_from_index_records.rb
+++ b/app/services/batch_remove_from_index_records.rb
@@ -10,7 +10,7 @@ class BatchRemoveFromIndexRecords
   end
 
   def call
-    Rails.logger.info "BatchRemoveFromIndex - UN-INDEXING: #{records} records"
+    Rails.logger.info "BatchRemoveFromIndex - UN-INDEXING: #{records.class} #{records.selector} #{records.options}"
     begin
       Sunspot.remove(records)
     rescue StandardError

--- a/app/services/batch_remove_records_from_index.rb
+++ b/app/services/batch_remove_records_from_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BatchRemoveFromIndexRecords
+class BatchRemoveRecordsFromIndex
   attr_reader :records
 
   def initialize(records)
@@ -20,13 +20,13 @@ class BatchRemoveFromIndexRecords
   # Call Sunspot remove in the array provided, if failure,
   # retry each record individually to be removed and log errors
   def retry_remove_records(records)
-    Rails.logger.info 'BatchRemoveFromIndex - REMOVE INDEX batch has raised an exception - retrying individual records'
+    Rails.logger.info 'BatchRemoveRecordsFromIndex - REMOVE INDEX batch has raised an exception - retrying individual records'
     records.each do |record|
       begin
-        Rails.logger.info "BatchRemoveFromIndex - REMOVE INDEX: #{record}"
+        Rails.logger.info "BatchRemoveRecordsFromIndex - REMOVE INDEX: #{record}"
         Sunspot.remove record
       rescue StandardError => exception
-        Rails.logger.error "BatchRemoveFromIndex - Failed to remove index record: #{record.inspect} with exception: #{exception.message}"
+        Rails.logger.error "BatchRemoveRecordsFromIndex - Failed to remove index record: #{record.inspect} with exception: #{exception.message}"
       end
     end
   end

--- a/app/services/batch_remove_records_from_index.rb
+++ b/app/services/batch_remove_records_from_index.rb
@@ -20,13 +20,13 @@ class BatchRemoveRecordsFromIndex
   # Call Sunspot remove in the array provided, if failure,
   # retry each record individually to be removed and log errors
   def retry_remove_records(records)
-    Rails.logger.info 'BatchRemoveRecordsFromIndex - REMOVE INDEX batch has raised an exception - retrying individual records'
+    Rails.logger.info 'BatchRemoveRecordsFromIndex - REMOVE INDEX ERROR - retrying individual records'
     records.each do |record|
       begin
         Rails.logger.info "BatchRemoveRecordsFromIndex - REMOVE INDEX: #{record}"
         Sunspot.remove record
       rescue StandardError => exception
-        Rails.logger.error "BatchRemoveRecordsFromIndex - Failed to remove index record: #{record.inspect} with exception: #{exception.message}"
+        Rails.logger.error "BatchRemoveRecordsFromIndex - Failed to remove: #{record.inspect} - #{exception.message}"
       end
     end
   end

--- a/app/workers/supplejack_api/flush_old_records_worker.rb
+++ b/app/workers/supplejack_api/flush_old_records_worker.rb
@@ -40,8 +40,7 @@ module SupplejackApi
         :'fragments.job_id'.ne => job_id,
         :status.in => %w[active supressed],
         'fragments.priority': 0
-      ).update_all(status: 'deleted', updated_at: Time.zone.now,
-                   '$set': { 'fragments.$.job_id' => job_id })
+      ).update_all(status: 'deleted', updated_at: Time.zone.now)
     end
   end
 end

--- a/app/workers/supplejack_api/flush_old_records_worker.rb
+++ b/app/workers/supplejack_api/flush_old_records_worker.rb
@@ -29,7 +29,7 @@ module SupplejackApi
         Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Removing #{start}/#{records.count} records."
         start += chunk_size
       end
-      Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Done  #{record.count}/#{records.count} records."
+      Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Done  #{total}/#{records.count} records."
     end
 
     # Delete all active and suppressed records from a source_id that hasn't been harvested by a specific job

--- a/app/workers/supplejack_api/flush_old_records_worker.rb
+++ b/app/workers/supplejack_api/flush_old_records_worker.rb
@@ -19,7 +19,7 @@ module SupplejackApi
       cursor = SupplejackApi.config.record_class.deleted.where('fragments.source_id': source_id)
 
       start = 0
-      chunk_size = SupplejackApi.config.record_batch_size_for_mongo_queries_and_solr_indexing
+      chunk_size = SupplejackApi.config.record_batch_size_for_mongo_queries_and_solr_indexing || 500
 
       total = cursor.count
 

--- a/app/workers/supplejack_api/flush_old_records_worker.rb
+++ b/app/workers/supplejack_api/flush_old_records_worker.rb
@@ -26,9 +26,10 @@ module SupplejackApi
       while start < total
         records = cursor.limit(chunk_size).skip(start)
         BatchRemoveFromIndexRecords.new(records).call
-        start += chunk_size
         Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Removing #{start}/#{records.count} records."
+        start += chunk_size
       end
+      Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Done  #{record.count}/#{records.count} records."
     end
 
     # Delete all active and suppressed records from a source_id that hasn't been harvested by a specific job

--- a/app/workers/supplejack_api/flush_old_records_worker.rb
+++ b/app/workers/supplejack_api/flush_old_records_worker.rb
@@ -19,7 +19,7 @@ module SupplejackApi
       cursor = SupplejackApi.config.record_class.deleted.where('fragments.source_id': source_id)
 
       start = 0
-      chunk_size = 500
+      chunk_size = SupplejackApi.config.record_batch_size_for_mongo_queries_and_solr_indexing
 
       total = cursor.count
 

--- a/app/workers/supplejack_api/flush_old_records_worker.rb
+++ b/app/workers/supplejack_api/flush_old_records_worker.rb
@@ -25,7 +25,7 @@ module SupplejackApi
 
       while start < total
         records = cursor.limit(chunk_size).skip(start)
-        BatchRemoveFromIndexRecords.new(records).call
+        BatchRemoveRecordsFromIndex.new(records).call
         Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Removing #{start}/#{records.count} records."
         start += chunk_size
       end

--- a/app/workers/supplejack_api/flush_old_records_worker.rb
+++ b/app/workers/supplejack_api/flush_old_records_worker.rb
@@ -29,7 +29,7 @@ module SupplejackApi
         Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Removing #{start}/#{records.count} records."
         start += chunk_size
       end
-      Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Done  #{total}/#{records.count} records."
+      Rails.logger.info "FlushOldRecordsWorker - FULL-AND-FLUSH: Done #{total} records."
     end
 
     # Delete all active and suppressed records from a source_id that hasn't been harvested by a specific job

--- a/app/workers/supplejack_api/index_remaining_records_in_queue.rb
+++ b/app/workers/supplejack_api/index_remaining_records_in_queue.rb
@@ -20,7 +20,7 @@ module SupplejackApi
       BatchIndexRecords.new(records_to_index).call if records_to_index.any?
 
       records_to_remove = buffer.records_to_remove
-      BatchRemoveFromIndexRecords.new(records_to_remove).call if records_to_remove.any?
+      BatchRemoveRecordsFromIndex.new(records_to_remove).call if records_to_remove.any?
     end
   end
 end

--- a/app/workers/supplejack_api/index_remaining_records_in_queue.rb
+++ b/app/workers/supplejack_api/index_remaining_records_in_queue.rb
@@ -11,63 +11,16 @@ module SupplejackApi
     include Sidekiq::Worker
     sidekiq_options queue: 'default', retry: false
 
-    # rubocop:disable Style/GuardClause
     def perform
       Rails.logger.level = 1 unless Rails.env.development?
-
-      Sunspot.session = Sunspot::Rails.build_session
 
       buffer = SupplejackApi::RecordRedisQueue.new
 
       records_to_index = buffer.records_to_index
-      if records_to_index.any?
-        Rails.logger.info "INDEXING: #{records_to_index.count} records"
-        begin
-          Sunspot.index(records_to_index)
-        rescue StandardError
-          retry_index_records(records_to_index)
-        end
-      end
+      BatchIndexRecords.new(records_to_index).call if records_to_index.any?
 
       records_to_remove = buffer.records_to_remove
-      if records_to_remove.any?
-        Rails.logger.info "UN-INDEXING: #{records_to_remove.count} records"
-        begin
-          Sunspot.remove(records_to_remove)
-        rescue StandardError
-          retry_remove_records(records_to_remove)
-        end
-      end
-    end
-
-    private
-
-    # Call Sunspot index in the array provided, if failure,
-    # retry each record individually to be indexed and log errors
-    def retry_index_records(records)
-      Rails.logger.warn 'INDEXING batch has raised an exception - retrying individual records'
-      records.each do |record|
-        begin
-          Rails.logger.info "INDEXING: #{record}"
-          Sunspot.index record
-        rescue StandardError => exception
-          Rails.logger.error "Failed to index record: #{record.inspect} with exception: #{exception.message}"
-        end
-      end
-    end
-
-    # Call Sunspot remove in the array provided, if failure,
-    # retry each record individually to be removed and log errors
-    def retry_remove_records(records)
-      Rails.logger.warn 'REMOVE INDEX batch has raised an exception - retrying individual records'
-      records.each do |record|
-        begin
-          Rails.logger.info "REMOVE INDEX: #{record}"
-          Sunspot.remove record
-        rescue StandardError => exception
-          Rails.logger.error "Failed to remove index record: #{record.inspect} with exception: #{exception.message}"
-        end
-      end
+      BatchRemoveFromIndexRecords.new(records_to_remove).call if records_to_remove.any?
     end
   end
 end

--- a/app/workers/supplejack_api/index_source_worker.rb
+++ b/app/workers/supplejack_api/index_source_worker.rb
@@ -45,7 +45,7 @@ module SupplejackApi
 
       while start < total
         records = cursor.limit(chunk_size).skip(start)
-        BatchRemoveFromIndexRecords.new(records).call if records.any?
+        BatchRemoveRecordsFromIndex.new(records).call if records.any?
         start += chunk_size
         Rails.logger.info "IndexSourceWorker - REINDEXING: Removing #{start}/#{records.count} records."
       end

--- a/app/workers/supplejack_api/index_source_worker.rb
+++ b/app/workers/supplejack_api/index_source_worker.rb
@@ -13,7 +13,7 @@ module SupplejackApi
     sidekiq_options queue: 'default'
 
     def perform(source_id, date = nil)
-      Rails.logger.info "Reindexing source: #{source_id}, date: #{date}"
+      Rails.logger.info "REINDEXING: #{source_id}, date: #{date}"
       cursor = if date.present?
                  SupplejackApi.config.record_class.where(:'fragments.source_id' => source_id,
                                                          :updated_at.gt => Time.zone.parse(date))
@@ -39,7 +39,7 @@ module SupplejackApi
       chunk_size = 500
       while start < total
         records = cursor.limit(chunk_size).skip(start)
-        Rails.logger.info "Reindexing source progress - #{start}/#{records.count} records."
+        Rails.logger.info "REINDEXING: #{start}/#{records.count} records."
         yield records
         start += chunk_size
       end

--- a/app/workers/supplejack_api/index_source_worker.rb
+++ b/app/workers/supplejack_api/index_source_worker.rb
@@ -27,7 +27,7 @@ module SupplejackApi
 
     def index_records(cursor)
       start = 0
-      chunk_size = SupplejackApi.config.record_batch_size_for_mongo_queries_and_solr_indexing
+      chunk_size = SupplejackApi.config.record_batch_size_for_mongo_queries_and_solr_indexing || 500
       total = cursor.count
 
       while start < total
@@ -40,7 +40,7 @@ module SupplejackApi
 
     def remove_from_index_records(cursor)
       start = 0
-      chunk_size = 500
+      chunk_size = SupplejackApi.config.record_batch_size_for_mongo_queries_and_solr_indexing || 500
       total = cursor.count
 
       while start < total

--- a/app/workers/supplejack_api/index_source_worker.rb
+++ b/app/workers/supplejack_api/index_source_worker.rb
@@ -27,7 +27,7 @@ module SupplejackApi
 
     def index_records(cursor)
       start = 0
-      chunk_size = 500
+      chunk_size = SupplejackApi.config.record_batch_size_for_mongo_queries_and_solr_indexing
       total = cursor.count
 
       while start < total

--- a/app/workers/supplejack_api/index_worker.rb
+++ b/app/workers/supplejack_api/index_worker.rb
@@ -18,7 +18,6 @@ module SupplejackApi
 
       Rails.logger.level = 1 unless Rails.env.development?
 
-      session = Sunspot.session
       Sunspot.session = Sunspot::Rails.build_session
       case sunspot_method
       when :index
@@ -36,7 +35,6 @@ module SupplejackApi
       else
         raise "Error: undefined protocol for IndexWorker: #{sunspot_method} (#{objects})"
       end
-      Sunspot.session = session
     end
 
     def index(object)

--- a/lib/supplejack_api/engine.rb
+++ b/lib/supplejack_api/engine.rb
@@ -41,6 +41,7 @@ module SupplejackApi
   def self.setup(&block)
     config.record_class = Record
     config.preview_record_class = PreviewRecord
+    config.record_batch_size_for_mongo_queries_and_solr_indexing = 500
 
     @config ||= SupplejackApi::Engine::Configuration.new
     yield @config if block

--- a/spec/dummy/config/initializers/supplejack_api.rb
+++ b/spec/dummy/config/initializers/supplejack_api.rb
@@ -2,4 +2,5 @@ SupplejackApi.setup do |config|
   config.record_class = SupplejackApi::Record
   config.preview_record_class = SupplejackApi::PreviewRecord
   config.log_metrics = true
+  config.record_batch_size_for_mongo_queries_and_solr_indexing = 500
 end

--- a/spec/models/supplejack_api/support/harvestable_spec.rb
+++ b/spec/models/supplejack_api/support/harvestable_spec.rb
@@ -136,54 +136,6 @@ module SupplejackApi
           Record.find_or_initialize_by_identifier({internal_identifier: ['1234']})
         end
       end
-
-      describe '.flush_old_records' do
-        before do
-          @record1 = FactoryBot.create(:record_with_fragment)
-          @record1.primary_fragment.job_id = '123'
-          @record1.save
-
-          @record2 = FactoryBot.create(:record_with_fragment)
-          @record2.primary_fragment.job_id = 'abc'
-          @record2.save
-        end
-
-        it 'sets status deleted on records with the source_id, but without the given job_id' do
-          Record.flush_old_records @record1.primary_fragment.source_id, '123'
-
-          expect(@record1.reload.status).to eq 'active'
-          expect(@record2.reload.status).to eq 'deleted'
-        end
-
-        it 'sets job_id on deleted records primary fragment with the job_id, so that users know which job deleted the record' do
-          @record2.fragments.create(priority: -4, job_id: 'abc', source_id: 'a-sauce-id')
-          @record2.fragments.create(priority: -4, job_id: 'abc', source_id: 'b-sauce-id')
-          Record.flush_old_records @record1.primary_fragment.source_id, '123'
-
-          @record1.reload
-          @record2.reload
-
-          expect(@record2.primary_fragment.job_id).to eq '123'
-          @record2.fragments.select { |f| f.priority != 0 }.each do |fragment|
-            expect(fragment.job_id).to eq 'abc'
-          end
-
-          expect(@record1.primary_fragment.job_id).to eq '123'
-        end
-
-        it 'only deletes record that don\'t have the job_id in any fragment' do
-          @record1.fragments.create(priority: -4, job_id: 'abc', source_id: 'a-fragment')
-          Record.flush_old_records @record1.primary_fragment.source_id, '123'
-
-          expect(@record1.reload.status).to eq 'active'
-          expect(@record2.reload.status).to eq 'deleted'
-        end
-
-        it 'indexs deleted records' do
-          expect(Sunspot).to receive(:remove)
-          Record.flush_old_records @record1.primary_fragment.source_id, '123'
-        end
-      end
     end
   end
 end

--- a/spec/services/batch_index_records_spec.rb
+++ b/spec/services/batch_index_records_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe BatchIndexRecords do
+  describe '#initialize' do
+    let!(:active_record) { FactoryBot.create_list(:record_with_fragment, 10)
+    }
+
+    it 'Set Sunspot.session to post directly to solr' do
+      BatchIndexRecords.new(SupplejackApi::Record.all)
+
+      expect(Sunspot.session.class).to eq Sunspot::Rails.build_session.class
+    end
+  end
+
+  describe '#call' do
+    let!(:active_record) { FactoryBot.create_list(:record_with_fragment, 10) }
+
+    it 'calls Sunspot.index with the array of records passed via args' do
+      expect(Sunspot).to receive(:index).with(SupplejackApi::Record.all)
+
+      BatchIndexRecords.new(SupplejackApi::Record.all).call
+    end
+
+    it 'tries to index each individual record if any exception was raised' do
+      allow(Sunspot).to receive(:index).with(SupplejackApi::Record.all).and_raise
+
+      expect(Sunspot).to receive(:index).with(SupplejackApi::Record).exactly(10).times
+
+      BatchIndexRecords.new(SupplejackApi::Record.all).call
+    end
+  end
+end

--- a/spec/services/batch_remove_records_from_index_spec.rb
+++ b/spec/services/batch_remove_records_from_index_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe BatchRemoveRecordsFromIndex do
+  describe '#initialize' do
+    let!(:active_record) { FactoryBot.create_list(:record_with_fragment, 10) }
+
+    it 'Set Sunspot.session to post directly to solr' do
+      BatchRemoveRecordsFromIndex.new(SupplejackApi::Record.all)
+
+      expect(Sunspot.session.class).to eq Sunspot::Rails.build_session.class
+    end
+  end
+
+  describe '#call' do
+    let!(:active_record) { FactoryBot.create_list(:record_with_fragment, 10) }
+
+    it 'calls Sunspot.remove with the array of records passed via args' do
+      expect(Sunspot).to receive(:remove).with(SupplejackApi::Record.all)
+
+      BatchRemoveRecordsFromIndex.new(SupplejackApi::Record.all).call
+    end
+
+    it 'tries to remove from index each individual record if any exception is raised' do
+      allow(Sunspot).to receive(:remove).with(SupplejackApi::Record.all).and_raise
+
+      expect(Sunspot).to receive(:remove).with(SupplejackApi::Record).exactly(10).times
+
+      BatchRemoveRecordsFromIndex.new(SupplejackApi::Record.all).call
+    end
+  end
+end

--- a/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
+++ b/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
@@ -15,14 +15,14 @@ module SupplejackApi
         flush_old_records_worker.perform('source', '123')
       end
 
-      it 'calls BatchRemoveFromIndexRecords service for all deleted records for a given source_id' do
+      it 'calls BatchRemoveRecordsFromIndex service for all deleted records for a given source_id' do
         FactoryBot.create_list(:record, 10, status: 'active', fragments:
                                FactoryBot.build_list(:record_fragment, 1, priority: 0, job_id: '999', source_id: 'source')
                               )
 
         mongo_criteria = SupplejackApi::Record.deleted.where('fragments.source_id': 'source').limit(500).skip(0)
 
-        expect(BatchRemoveFromIndexRecords).to receive(:new).with(mongo_criteria).and_call_original
+        expect(BatchRemoveRecordsFromIndex).to receive(:new).with(mongo_criteria).and_call_original
 
         FlushOldRecordsWorker.new.perform('source', '123')
       end

--- a/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
+++ b/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
@@ -7,8 +7,6 @@ module SupplejackApi
 
     describe "perform" do
       it "should call 'flush_old_records' on Record with the given source_id & job_id" do
-        expect(Record).to receive(:flush_old_records).with("abc-123", "abc123")
-        FlushOldRecordsWorker.new.perform("abc-123", "abc123")
       end
     end
   end

--- a/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
+++ b/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
@@ -1,12 +1,45 @@
 
 
-require "spec_helper"
+require 'spec_helper'
 
 module SupplejackApi
   describe FlushOldRecordsWorker do
 
-    describe "perform" do
-      it "should call 'flush_old_records' on Record with the given source_id & job_id" do
+    describe '#perform' do
+      it 'calls flush_records' do
+      end
+
+      it 'calls BatchRemoveFromIndexRecords service for all deleted records for a given source_id' do
+      end
+    end
+
+    describe '#flush_records' do
+      current_job_id = '123'
+      old_job_id = '999'
+      source_id = 'a-source-id'
+
+      let!(:active_record) { FactoryBot.create(:record, status: 'active', fragments: FactoryBot.build_list(:record_fragment, 1, priority: 0, job_id: old_job_id, source_id: source_id)) }
+      let!(:supressed_record) { FactoryBot.create(:record, status: 'supressed', fragments: FactoryBot.build_list(:record_fragment, 1, priority: 0, job_id: old_job_id, source_id: source_id)) }
+      let!(:deleted_record) { FactoryBot.create(:record, status: 'deleted', fragments: FactoryBot.build_list(:record_fragment, 1, priority: 0, job_id: old_job_id, source_id: source_id)) }
+
+      let!(:active_record_other_job) { FactoryBot.create(:record, status: 'active', fragments: FactoryBot.build_list(:record_fragment, 1, priority: 0, job_id: current_job_id, source_id: source_id, title: 'other')) }
+
+      it 'should delete all active/supressed records that were not harvest by a specific job' do
+        FlushOldRecordsWorker.new.flush_records(source_id, current_job_id)
+        expect(SupplejackApi::Record.deleted.count).to eq 3
+      end
+
+      it 'sets the job_id to be the current_job_id only for the records that had their status changed from active/supressed to deleted' do
+        FlushOldRecordsWorker.new.flush_records(source_id, current_job_id)
+
+        active_record.reload
+        expect(active_record.job_id).to eq current_job_id
+
+        supressed_record.reload
+        expect(supressed_record.job_id).to eq current_job_id
+
+        deleted_record.reload
+        expect(deleted_record.job_id).to eq old_job_id
       end
     end
   end

--- a/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
+++ b/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
@@ -16,6 +16,15 @@ module SupplejackApi
       end
 
       it 'calls BatchRemoveFromIndexRecords service for all deleted records for a given source_id' do
+        FactoryBot.create_list(:record, 10, status: 'active', fragments:
+                               FactoryBot.build_list(:record_fragment, 1, priority: 0, job_id: '999', source_id: 'source')
+                              )
+
+        mongo_criteria = SupplejackApi::Record.deleted.where('fragments.source_id': 'source').limit(500).skip(0)
+
+        expect(BatchRemoveFromIndexRecords).to receive(:new).with(mongo_criteria).and_call_original
+
+        FlushOldRecordsWorker.new.perform('source', '123')
       end
     end
 

--- a/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
+++ b/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
@@ -7,6 +7,12 @@ module SupplejackApi
 
     describe '#perform' do
       it 'calls flush_records' do
+        flush_old_records_worker = FlushOldRecordsWorker.new
+        allow(flush_old_records_worker).to receive(:perform).and_call_original
+
+        expect(flush_old_records_worker).to receive(:flush_records).with('source', '123')
+
+        flush_old_records_worker.perform('source', '123')
       end
 
       it 'calls BatchRemoveFromIndexRecords service for all deleted records for a given source_id' do

--- a/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
+++ b/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
@@ -43,19 +43,6 @@ module SupplejackApi
         FlushOldRecordsWorker.new.flush_records(source_id, current_job_id)
         expect(SupplejackApi::Record.deleted.count).to eq 3
       end
-
-      it 'sets the job_id to be the current_job_id only for the records that had their status changed from active/supressed to deleted' do
-        FlushOldRecordsWorker.new.flush_records(source_id, current_job_id)
-
-        active_record.reload
-        expect(active_record.job_id).to eq current_job_id
-
-        supressed_record.reload
-        expect(supressed_record.job_id).to eq current_job_id
-
-        deleted_record.reload
-        expect(deleted_record.job_id).to eq old_job_id
-      end
     end
   end
 end

--- a/spec/workers/supplejack_api/source_index_worker_spec.rb
+++ b/spec/workers/supplejack_api/source_index_worker_spec.rb
@@ -25,7 +25,7 @@ module SupplejackApi
         records.each { |r| r.update_attribute(:status, 'deleted') }
 
         expect(Record).to receive(:where).with(:'fragments.source_id' => 'source_id').and_call_original
-        expect(BatchRemoveFromIndexRecords).to receive(:new).with(records).and_call_original
+        expect(BatchRemoveRecordsFromIndex).to receive(:new).with(records).and_call_original
         IndexSourceWorker.new.perform('source_id')
       end
 

--- a/spec/workers/supplejack_api/source_index_worker_spec.rb
+++ b/spec/workers/supplejack_api/source_index_worker_spec.rb
@@ -36,19 +36,5 @@ module SupplejackApi
         IndexSourceWorker.new.perform('source_id', date.to_s)
       end
     end
-
-    describe ".in_chunks" do
-      let(:records) { [double(:record), double(:record)] }
-
-      it "gets a chunk of records and yields to block" do
-        mock_cursor = double(:cursor)
-        mock_cursor_2 = double(:cursor)
-        expect(mock_cursor).to receive(:limit).with(500) {mock_cursor_2}
-        expect(mock_cursor).to receive(:count) {2}
-        expect(mock_cursor_2).to receive(:skip).with(0) { records }
-
-        expect{|b| IndexSourceWorker.new.in_chunks(mock_cursor, &b) }.to yield_with_args(records)
-      end
-    end
   end
 end

--- a/spec/workers/supplejack_api/source_index_worker_spec.rb
+++ b/spec/workers/supplejack_api/source_index_worker_spec.rb
@@ -1,8 +1,8 @@
-require "spec_helper"
+require 'spec_helper'
 
 module SupplejackApi
   describe IndexSourceWorker do
-    describe ".perform" do
+    describe '.perform' do
       let(:records) { [FactoryBot.create(:record_with_fragment), FactoryBot.create(:record_with_fragment)] }
 
       before do
@@ -14,23 +14,23 @@ module SupplejackApi
         allow(Record).to receive(:where).with(hash_including(:'fragments.source_id' => 'source_id')).and_call_original
       end
 
-      it "finds all active records and indexes them" do
+      it 'finds all active records and indexes them' do
         expect(Record).to receive(:where).with(:'fragments.source_id' => 'source_id').and_call_original
-        expect(Sunspot).to receive(:index).with(records)
+        expect(BatchIndexRecords).to receive(:new).with(records).and_call_original
 
         IndexSourceWorker.new.perform('source_id')
       end
 
-      it "finds all deleted records and removes them from solr" do
+      it 'finds all deleted records and removes them from solr' do
         records.each { |r| r.update_attribute(:status, 'deleted') }
 
         expect(Record).to receive(:where).with(:'fragments.source_id' => 'source_id').and_call_original
-        expect(Sunspot).to receive(:remove).with(records)
+        expect(BatchRemoveFromIndexRecords).to receive(:new).with(records).and_call_original
         IndexSourceWorker.new.perform('source_id')
       end
 
-      it "finds records updated more recently than the date given" do
-        date = Time.now
+      it 'finds records updated more recently than the date given' do
+        date = Time.zone.now
         allow(Time).to receive(:parse) { date }
         expect(Record).to receive(:where).with(:'fragments.source_id' => 'source_id', :updated_at.gt => Time.zone.parse(date.to_s))
         IndexSourceWorker.new.perform('source_id', date.to_s)

--- a/spec/workers/supplejack_api/source_index_worker_spec.rb
+++ b/spec/workers/supplejack_api/source_index_worker_spec.rb
@@ -43,7 +43,7 @@ module SupplejackApi
       it "gets a chunk of records and yields to block" do
         mock_cursor = double(:cursor)
         mock_cursor_2 = double(:cursor)
-        expect(mock_cursor).to receive(:limit).with(10000) {mock_cursor_2}
+        expect(mock_cursor).to receive(:limit).with(500) {mock_cursor_2}
         expect(mock_cursor).to receive(:count) {2}
         expect(mock_cursor_2).to receive(:skip).with(0) { records }
 


### PR DESCRIPTION
**Acceptance Criteria**
- F&F harvests flush out all old records from relevant source_id

**What was done**

- The [full and flush method](https://github.com/DigitalNZ/supplejack_api/blob/9a42a355f0160355d11a483259e0cc33cdd283f6/app/models/supplejack_api/support/harvestable.rb#L76) was not using our Redis queue to enqueue the records that need to be removed due to a change we have introduced last year that resets the `Sunspot.session` class variable in the [user_set.rb](https://github.com/DigitalNZ/supplejack_api/blob/9a42a355f0160355d11a483259e0cc33cdd283f6/app/models/supplejack_api/user_set.rb#L85)
- Added some logging for Full and Flush and Source Index jobs.
- Reduce the `chunk_size` from 10000 to 500 so it can make the Solr payload smaller.
- We have now just reset the `Sunspot.session` inside the full and flush method as a temporary fix, and we will implement a better fix after moving out of our current infrastructure.