### PR TITLE
METRICS 0 COUNTS: As Adam from Auckland Museum, I want  the metrics logging fixed so that I don't get 0 counts for top records.

### DIFF
--- a/app/models/supplejack_api/top_collection_metric.rb
+++ b/app/models/supplejack_api/top_collection_metric.rb
@@ -98,6 +98,7 @@ module SupplejackApi
     def self.record_metrics_to_be_processed(date, metric, display_collection)
       SupplejackApi::RecordMetric.where(
         date: date,
+        metric.ne => 0,
         display_collection: display_collection,
         :processed_by_top_collection_metrics.in => [nil, '', false]
       ).order_by(metric => 'desc').limit(200)

--- a/app/models/supplejack_api/top_metric.rb
+++ b/app/models/supplejack_api/top_metric.rb
@@ -33,6 +33,7 @@ module SupplejackApi
 
     def self.spawn
       return unless SupplejackApi.config.log_metrics == true
+
       dates = SupplejackApi::RecordMetric.where(:date.lt => Time.zone.now.beginning_of_day).map(&:date).uniq
 
       dates.each do |date|
@@ -41,6 +42,8 @@ module SupplejackApi
           results = record_metrics.each_with_object({}) do |record, hash|
             hash[record.record_id.to_s] = record.send(metric)
           end
+
+          next if results.empty?
 
           metric = find_or_create_by(
             date: date,
@@ -63,6 +66,7 @@ module SupplejackApi
     def self.record_metrics_to_be_processed(date, metric)
       SupplejackApi::RecordMetric.where(
         date: date,
+        metric.ne => 0,
         :processed_by_top_metrics.in => [nil, '', false]
       ).order_by(metric => 'desc').limit(200)
     end

--- a/spec/models/supplejack_api/top_collection_metric_spec.rb
+++ b/spec/models/supplejack_api/top_collection_metric_spec.rb
@@ -79,5 +79,17 @@ RSpec.describe SupplejackApi::TopCollectionMetric, type: :model do
         expect(tcm.class).to eql described_class
       end
     end
+
+    it 'does not include records that have 0 of the requested metric in the results' do
+      expect(SupplejackApi::TopCollectionMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches', display_collection: 'Laramie').results.values.uniq).not_to include 0
+    end
+
+    it 'only includes records that have valid data' do
+      expect(SupplejackApi::TopCollectionMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches', display_collection: 'Laramie').results.count).to eq 4
+    end
+
+    it 'doesn\'t create top collection metrics when there are no results' do
+      expect( SupplejackApi::TopCollectionMetric.where(display_collection: 'Collecty McCollectyface').map(&:metric)).not_to include 'page_views'
+    end
   end
 end

--- a/spec/models/supplejack_api/top_metric_spec.rb
+++ b/spec/models/supplejack_api/top_metric_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe SupplejackApi::TopMetric do
       SupplejackApi::TopMetric.spawn
     end
 
-    it 'creates TopMetrics for each metric' do
-      expect(SupplejackApi::TopMetric.all.map(&:metric).uniq.sort).to eq ['added_to_user_sets', 'added_to_user_stories', 'appeared_in_searches', 'page_views', 'source_clickthroughs', 'user_set_views', 'user_story_views']
-    end
-
     it 'only takes the top 200 records for each metric' do
       expect(SupplejackApi::TopMetric.find_by(date: Time.zone.yesterday, metric: 'page_views').results.keys.count).to eq 200
     end
@@ -56,7 +52,19 @@ RSpec.describe SupplejackApi::TopMetric do
 
       expect(SupplejackApi::TopMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches').results.values.first).to eq 4
       expect(SupplejackApi::TopMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches'))
-      expect(SupplejackApi::TopMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches').results.keys.count).to eq 200
+      expect(SupplejackApi::TopMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches').results.count).to eq 4
+    end
+
+    it 'does not add records that have a 0 count into the top results' do
+      expect(SupplejackApi::TopMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches').results.values.uniq).not_to include 0
+    end
+
+    it 'only returns the record counts that have important data' do
+      expect(SupplejackApi::TopMetric.find_by(date: Time.zone.yesterday, metric: 'appeared_in_searches').results.count).to eq 3
+    end
+
+    it 'doesn\'t create records top metrics that have no results' do
+      expect(SupplejackApi::TopMetric.all.map(&:metric)).not_to include 'user_set_views'
     end
   end
 end


### PR DESCRIPTION
**Acceptance Criteria**
- Metrics logging no longer records 0 against top records metrics (top collection metrics) 
- Includes historic data clean up 