### PR TITLE
SOURCE ID's MISSING FROM STAGING: As Tonya, I want new source_id's to be added to both staging and prod, so that all the things work.

### DIFF
--- a/app/models/supplejack_api/source.rb
+++ b/app/models/supplejack_api/source.rb
@@ -6,15 +6,12 @@ module SupplejackApi
 
     store_in collection: 'sources', client: 'strong'
 
-    field :name,                 type: String
     field :source_id,            type: String
     field :status,               type: String, default: 'active'
     field :status_updated_by,    type: String
     field :status_updated_at,    type: DateTime
 
     belongs_to :partner, class_name: 'SupplejackApi::Partner'
-
-    validates :name, presence: true
 
     scope :suppressed,  -> { where(status: 'suppressed') }
 

--- a/spec/controllers/supplejack_api/harvester/sources_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/sources_controller_spec.rb
@@ -32,10 +32,10 @@ module SupplejackApi
 
         context 'source already exists' do
           it 'updates the source' do
-            source = partner.sources.create(FactoryBot.attributes_for(:source, name: "source_1"))
-            post :create, params: { partner_id: partner, source: {_id: source.id, name: 'source2'}, api_key: api_key}
+            source = partner.sources.create(FactoryBot.attributes_for(:source, source_id: "source_1"))
+            post :create, params: { partner_id: partner, source: {_id: source.id, source_id: 'source2'}, api_key: api_key}
             source.reload
-            expect(source.name).to eq 'source2'
+            expect(source.source_id).to eq 'source2'
           end
         end
       end

--- a/spec/factories/sources.rb
+++ b/spec/factories/sources.rb
@@ -4,7 +4,6 @@ module SupplejackApi
   FactoryBot.define do
     factory :source, class: SupplejackApi::Source do
       association :partner, factory: :partner
-      name        'Sample source'
       source_id   '1234'
     end
   end


### PR DESCRIPTION
**Acceptance Criteria**
- New source_id's are added everywhere they are meant to be
- Existing source_id's are synced up between prod and staging