### PR TITLE
SETUP SEPARATE SIDEKIQ QUEUES OUT OF THE BOX

### DIFF
--- a/spec/dummy/config/application.yml
+++ b/spec/dummy/config/application.yml
@@ -9,7 +9,7 @@ defaults: &defaults
   REQUEST_LIMIT_MAILER: 'develop@example.com'
   MONGOID_HOSTS: 'localhost:27017'
   WWW_DOMAIN: 'www.dev'
-  REDIS_URL: 'redis://localhost:6379/12'
+  REDIS_URL: 'redis://localhost:6379/1'
 
 development:
   <<: *defaults


### PR DESCRIPTION
Supplejack has it’s own instance of Sidekiq that you will need to run for the Full and Flush harvest to work. Start Sidekiq from the api directory with bundle exec sidekiq. If you are running both Sidekiq instances on the same machine, you will need to point them at separate Redis databases otherwise you will end up in problems where the two Sidekiqs are trying to process each others jobs. This can be done by appending /<number> to the end of your Redis URL.