### PR TITLE
FIX API POD ISSUES

### DIFF
--- a/app/models/supplejack_api/collection_metric.rb
+++ b/app/models/supplejack_api/collection_metric.rb
@@ -7,7 +7,7 @@ module SupplejackApi
     include Mongoid::Timestamps
     include SupplejackApi::Concerns::QueryableByDate
 
-    field :d, as: :date,                               type: Date,    default: Time.current.utc
+    field :d, as: :date,                               type: Date,    default: Time.zone.now
     field :dc, as: :display_collection,                type: String
     field :s, as: :searches,                           type: Integer, default: 0
     field :rpv, as: :record_page_views,                type: Integer, default: 0

--- a/app/models/supplejack_api/top_collection_metric.rb
+++ b/app/models/supplejack_api/top_collection_metric.rb
@@ -17,7 +17,7 @@ module SupplejackApi
       added_to_user_stories
     ].freeze
 
-    field :d, as: :date,               type: Date, default: Time.current.utc
+    field :d, as: :date,               type: Date, default: Time.zone.now
     field :m, as: :metric,             type: String
     field :r, as: :results,            type: Hash
     field :c, as: :display_collection, type: String

--- a/app/models/supplejack_api/top_metric.rb
+++ b/app/models/supplejack_api/top_metric.rb
@@ -23,7 +23,7 @@ module SupplejackApi
       added_to_user_stories
     ].freeze
 
-    field :d, as: :date,    type: Date, default: Time.current.utc
+    field :d, as: :date,    type: Date, default: Time.zone.now
     field :m, as: :metric,  type: String
     field :r, as: :results, type: Hash
 

--- a/app/models/supplejack_api/user.rb
+++ b/app/models/supplejack_api/user.rb
@@ -104,7 +104,7 @@ module SupplejackApi
 
     def update_tracked_fields(request)
       old_current = current_sign_in_at
-      new_current = Time.now.utc
+      new_current = Time.zone.now
       self.last_sign_in_at     = old_current || new_current
       self.current_sign_in_at  = new_current
 

--- a/app/models/supplejack_api/user_set.rb
+++ b/app/models/supplejack_api/user_set.rb
@@ -173,12 +173,7 @@ module SupplejackApi
 
       self.featured = featured_value
 
-      # This cop is being disabled until can be sure
-      # whether or not we want to set `Time.zone.now`
-      # or keep `Time.now`
-      # rubocop:disable Rails/TimeZone
-      self.featured_at = Time.now if featured_changed?
-      # rubocop:enable Rails/TimeZone
+      self.featured_at = Time.zone.now if featured_changed?
     end
 
     def update_set_items(new_attributes)

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -21,11 +21,13 @@ class BatchIndexRecords
   # retry each record individually to be indexed and log errors
   def retry_index_records(records)
     Rails.logger.info 'BatchIndexRecords - INDEXING batch has raised an exception - retrying individual records'
-    records.each do |record|
-      Rails.logger.info "BatchIndexRecords - INDEXING: #{record}"
-      Sunspot.index record
-    rescue StandardError => e
-      Rails.logger.error "BatchIndexRecords - Failed to index: #{record.inspect} - #{e.message}"
-    end
+    records.each { |record| index_individual_record(record) }
+  end
+
+  def index_individual_record(record)
+    Rails.logger.info "BatchIndexRecords - INDEXING: #{record}"
+    Sunspot.index record
+  rescue StandardError => e
+    Rails.logger.error "BatchIndexRecords - Failed to index: #{record.inspect} - #{e.message}"
   end
 end

--- a/lib/generators/supplejack_api/install_generator.rb
+++ b/lib/generators/supplejack_api/install_generator.rb
@@ -21,7 +21,7 @@ module SupplejackApi
         puts "\nGenerating secret token"
 
         inject_into_file('config/application.yml', before: /^\sdevelopment:/) do
-          "  SECRET_TOKEN: '#{Digest::SHA1.hexdigest([Time.now, rand].join)}'\n"
+          "  SECRET_TOKEN: '#{Digest::SHA1.hexdigest([Time.zone.now, rand].join)}'\n"
         end
       end
 

--- a/spec/controllers/supplejack_api/harvester/sources_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/sources_controller_spec.rb
@@ -99,11 +99,11 @@ module SupplejackApi
         let(:source) { FactoryBot.create(:source) }
 
         it 'finds and update source with status, status_updated_at and status_updated_by' do
-          Timecop.freeze # check if Time.now was assigned to status_updated_at
+          Timecop.freeze # check if Time.zone.now was assigned to status_updated_at
           put :update, params: { id: source.id, source: {status: 'suppressed', status_updated_by: 'A user name'}, api_key: api_key}
           expect(assigns(:source).status).to eq 'suppressed'
           expect(assigns(:source).status_updated_by).to eq 'A user name'
-          expect(assigns(:source).status_updated_at).to eq Time.now
+          expect(assigns(:source).status_updated_at).to eq Time.zone.now
         end
 
         it 'returns the source' do
@@ -118,7 +118,7 @@ module SupplejackApi
         let(:source) { create(:source) }
 
         it "enqueues the job with the source_id and date if given" do
-          date = Time.now
+          date = Time.zone.now
           expect(IndexSourceWorker).to receive(:perform_async).with(source.source_id, date.to_s)
           get :reindex, params: { id: source.id, date: date, api_key: api_key}
         end
@@ -168,7 +168,7 @@ module SupplejackApi
 
       describe 'GET "reindex"' do
         it 'returns forbidden' do
-          get :reindex, params: { id: 1, date: Time.now, api_key: api_key}
+          get :reindex, params: { id: 1, date: Time.zone.now, api_key: api_key}
           expect(response).to be_forbidden
         end
       end

--- a/spec/dummy/README.rdoc
+++ b/spec/dummy/README.rdoc
@@ -63,7 +63,7 @@ using the Ruby logger class from inside your controllers. Example:
     def destroy
       @weblog = Weblog.find(params[:id])
       @weblog.destroy
-      logger.info("#{Time.now} Destroyed Weblog ID ##{@weblog.id}!")
+      logger.info("#{Time.zone.now} Destroyed Weblog ID ##{@weblog.id}!")
     end
   end
 

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -53,7 +53,7 @@ module SupplejackApi
       children        ['Sally Doe', 'James Doe']
       contact         nil
       age             30
-      birth_date      DateTime.now
+      birth_date      Time.zone.now
       nz_citizen      true
       display_collection 'test'
       large_thumbnail_url    'http://my-website-that-hosts-images/image.png'

--- a/spec/models/site_activity_spec.rb
+++ b/spec/models/site_activity_spec.rb
@@ -13,7 +13,7 @@ module SupplejackApi
         expect(SupplejackApi::SiteActivity.new(date: Date.today)).to_not be_valid
       end
     end
-    
+
     describe '.generate_activity' do
       ['user_sets', 'search', 'records'].each do |field|
         it 'agregates #{field} totals across all users' do
@@ -26,15 +26,15 @@ module SupplejackApi
       end
 
       it 'only agregates user activities from the last 12 hours' do
-        create(:user_activity, user_id: user.id, :search => {'total' => 10}, created_at: Time.now-14.hours)
+        create(:user_activity, user_id: user.id, :search => {'total' => 10}, created_at: Time.zone.now-14.hours)
         site_activity = SupplejackApi::SiteActivity.generate_activity
         expect(site_activity.search).to eq 0
       end
 
       it 'stores yesterday\'s date' do
-        Timecop.freeze(Time.now) do
+        Timecop.freeze(Time.zone.now) do
           site_activity = SupplejackApi::SiteActivity.generate_activity
-          expect(site_activity.date).to eq Time.now.to_date
+          expect(site_activity.date).to eq Time.zone.now.to_date
         end
       end
 
@@ -47,19 +47,19 @@ module SupplejackApi
       end
 
       context 'specify a date in the past' do
-        before do 
-          create(:user_activity, user_id: user.id, :records => {'total' => 10}, created_at: Time.now - 26.hours)
-          create(:user_activity, user_id: user.id, :user_sets => {'total' => 5}, created_at: Time.now - 28.hours)
+        before do
+          create(:user_activity, user_id: user.id, :records => {'total' => 10}, created_at: Time.zone.now - 26.hours)
+          create(:user_activity, user_id: user.id, :user_sets => {'total' => 5}, created_at: Time.zone.now - 28.hours)
         end
 
         it 'generates the site activity for a day in the past' do
-          site_activity = SupplejackApi::SiteActivity.generate_activity(Time.now-24.hours)
+          site_activity = SupplejackApi::SiteActivity.generate_activity(Time.zone.now-24.hours)
           expect(site_activity.total).to eq 15
         end
 
         it 'should add up user activity created after the date' do
-          create(:user_activity, user_id: user.id, :records => {'total' => 2}, created_at: Time.now)
-          site_activity = SupplejackApi::SiteActivity.generate_activity(Time.now-24.hours)
+          create(:user_activity, user_id: user.id, :records => {'total' => 2}, created_at: Time.zone.now)
+          site_activity = SupplejackApi::SiteActivity.generate_activity(Time.zone.now-24.hours)
           expect(site_activity.total).to eq 15
         end
 

--- a/spec/models/supplejack_api/api_concept/concept_fragment_spec.rb
+++ b/spec/models/supplejack_api/api_concept/concept_fragment_spec.rb
@@ -150,7 +150,7 @@ module SupplejackApi
       #   end
 
       #   it 'updates the updated_at even if the attributes didn\'t change' do
-      #     new_time = Time.now + 1.day
+      #     new_time = Time.zone.now + 1.day
       #     Timecop.freeze(new_time) do
       #       fragment.update_from_harvest({})
       #       expect(fragment.updated_at.to_i).to eq(new_time.to_i)

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe SupplejackApi::RecordMetric do
 
     let!(:record_metric)      { create(:record_metric) }
     let(:record_metric_two)   { build(:record_metric, record_id: record_metric.record_id) }
-    let(:record_metric_three) { build(:record_metric, date: 1.day.from_now.utc) }
+    let(:record_metric_three) { build(:record_metric, date: 1.day.from_now) }
 
     it 'requires a record_id' do
       invalid.valid?

--- a/spec/models/supplejack_api/record_spec.rb
+++ b/spec/models/supplejack_api/record_spec.rb
@@ -116,8 +116,8 @@ module SupplejackApi
       end
 
       it 'returns the records in the same order as requested' do
-        r1 = FactoryBot.create(:record, created_at: Time.now-10.days)
-        r2 = FactoryBot.create(:record, created_at: Time.now)
+        r1 = FactoryBot.create(:record, created_at: Time.zone.now-10.days)
+        r2 = FactoryBot.create(:record, created_at: Time.zone.now)
         records = Record.find_multiple([r2.record_id, r1.record_id]).to_a
         expect(records.first).to eq r2
       end

--- a/spec/models/supplejack_api/request_metric_spec.rb
+++ b/spec/models/supplejack_api/request_metric_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe SupplejackApi::RequestMetric do
 
   describe '#summarize' do
 
-    let!(:appeared_in_searches_yesterday) { create_list(:request_metric, 5, date: 1.day.ago.utc) }
-    let!(:user_set_views_yesterday) { create_list(:request_metric, 5, metric: 'user_set_views', date: 1.day.ago.utc) }
-    let!(:source_clickthroughs_yesterday) { create_list(:request_metric, 5, metric: 'source_clickthroughs', date: 1.day.ago.utc) }
+    let!(:appeared_in_searches_yesterday) { create_list(:request_metric, 5, date: 1.day.ago) }
+    let!(:user_set_views_yesterday) { create_list(:request_metric, 5, metric: 'user_set_views', date: 1.day.ago) }
+    let!(:source_clickthroughs_yesterday) { create_list(:request_metric, 5, metric: 'source_clickthroughs', date: 1.day.ago) }
 
     let!(:appeared_in_searches_today) { create_list(:request_metric, 5) }
     let!(:user_set_views_today) { create_list(:request_metric, 5, metric: 'user_set_views') }
@@ -38,10 +38,10 @@ RSpec.describe SupplejackApi::RequestMetric do
 
       expect(SupplejackApi::RecordMetric.count).to eq 8
 
-      yesterday_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: 1.day.ago.utc)
-      yesterday_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: 1.day.ago.utc)
-      yesterday_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: 1.day.ago.utc)
-      yesterday_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: 1.day.ago.utc)
+      yesterday_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: 1.day.ago)
+      yesterday_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: 1.day.ago)
+      yesterday_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: 1.day.ago)
+      yesterday_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: 1.day.ago)
 
       today_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: Time.zone.now)
       today_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: Time.zone.now)

--- a/spec/models/supplejack_api/top_collection_metric_spec.rb
+++ b/spec/models/supplejack_api/top_collection_metric_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupplejackApi::TopCollectionMetric, type: :model do
 
   describe '#attributes' do
     it 'has a date' do
-      expect(top_collection_metric.date).to eq Time.zone.now.utc.to_date
+      expect(top_collection_metric.date).to eq Time.zone.now.to_date
     end
 
     it 'has a metric' do

--- a/spec/models/supplejack_api/top_metric_spec.rb
+++ b/spec/models/supplejack_api/top_metric_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe SupplejackApi::TopMetric do
-  let(:top_metric) { create(:top_metric, results: { 1 => 200, 2 => 150 }, date: Time.zone.now.utc.to_date) }
+  let(:top_metric) { create(:top_metric, results: { 1 => 200, 2 => 150 }, date: Time.zone.now.to_date) }
 
   describe '#attributes' do
     it 'has a date' do
-      expect(top_metric.date).to eq Time.zone.now.utc.to_date
+      expect(top_metric.date).to eq Time.zone.now.to_date
     end
 
     it 'has a metric' do

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -362,7 +362,7 @@ module SupplejackApi
     describe "#featured_sets" do
       before :each do
         @record = FactoryBot.create(:record, status: "active")
-        @set1 = FactoryBot.create(:user_set, privacy: "public", featured: true, featured_at: Time.now - 4.hours)
+        @set1 = FactoryBot.create(:user_set, privacy: "public", featured: true, featured_at: Time.zone.now - 4.hours)
         @set1.set_items.create(record_id: @record.record_id)
         @set2 = FactoryBot.create(:user_set, privacy: "hidden", featured: true)
         @set2.set_items.create(record_id: @record.record_id)
@@ -375,7 +375,7 @@ module SupplejackApi
       end
 
       it "orders the sets based on when they were added" do
-        @set4 = FactoryBot.create(:user_set, privacy: "public", featured: true, featured_at: Time.now)
+        @set4 = FactoryBot.create(:user_set, privacy: "public", featured: true, featured_at: Time.zone.now)
         @set4.set_items.create(record_id: @record.record_id)
         expect(UserSet.featured_sets.first).to eq @set4
       end
@@ -449,18 +449,18 @@ module SupplejackApi
       it "should update the featured_at when the featured attribute is updated" do
         admin_user = FactoryBot.create(:user, role: "admin")
         user_set = FactoryBot.create(:user_set, user_id: admin_user.id)
-        Timecop.freeze(Time.now) do
+        Timecop.freeze(Time.zone.now) do
           user_set.update_attributes_and_embedded({featured: true}, admin_user)
           user_set.reload
-          expect(user_set.featured_at.to_i).to eq Time.now.to_i
+          expect(user_set.featured_at.to_i).to eq Time.zone.now.to_i
         end
       end
 
       it "should not update the featured_at if the featured hasn't changed" do
         admin_user = FactoryBot.create(:user, role: "admin")
-        time = Time.now-1.day
+        time = Time.zone.now-1.day
         user_set = FactoryBot.create(:user_set, user_id: admin_user.id, featured: true, featured_at: time)
-        Timecop.freeze(Time.now) do
+        Timecop.freeze(Time.zone.now) do
           user_set.update_attributes_and_embedded({featured: true}, admin_user)
           user_set.reload
           expect(user_set.featured_at.to_i).to eq time.to_i
@@ -469,7 +469,7 @@ module SupplejackApi
 
       it "removes the set from the featured" do
         admin_user = FactoryBot.create(:user, role: "admin")
-        time = Time.now-1.day
+        time = Time.zone.now-1.day
         user_set = FactoryBot.create(:user_set, user_id: admin_user.id, featured: true, featured_at: time)
         user_set.update_attributes_and_embedded({featured: false}, admin_user)
         user_set.reload

--- a/spec/models/supplejack_api/user_spec.rb
+++ b/spec/models/supplejack_api/user_spec.rb
@@ -66,25 +66,25 @@ module SupplejackApi
 
     describe '#updated_today?' do
       it 'should return true if the user was last updated today' do
-        user.updated_at = Time.now.beginning_of_day + 10.seconds
+        user.updated_at = Time.zone.now.beginning_of_day + 10.seconds
         expect(user.updated_today?).to be_truthy
       end
 
       it 'should return false when the user was last updated yesterday' do
-        user.updated_at = Time.now - 1.day
+        user.updated_at = Time.zone.now - 1.day
         expect(user.updated_today?).to be_falsey
       end
     end
 
     describe '#check_daily_requests' do
       it "should reset daily requests if it wasn't updated today" do
-        user.attributes = { updated_at: Time.now-1.day, daily_requests: 100 }
+        user.attributes = { updated_at: Time.zone.now-1.day, daily_requests: 100 }
         user.check_daily_requests
         expect(user.daily_requests).to eq 1
       end
 
       it 'should increment daily requests if it was updated today' do
-        user.attributes = { updated_at: Time.now, daily_requests: 100 }
+        user.attributes = { updated_at: Time.zone.now, daily_requests: 100 }
         user.check_daily_requests
         expect(user.daily_requests).to eq 101
       end
@@ -98,26 +98,26 @@ module SupplejackApi
 
         it 'should send an email if the user is at 90% daily requests' do
           expect(@email).to receive(:deliver_now)
-          user.attributes = {daily_requests: 89, updated_at: Time.now, max_requests: 100}
+          user.attributes = {daily_requests: 89, updated_at: Time.zone.now, max_requests: 100}
           expect(SupplejackApi::RequestLimitMailer).to receive(:at90percent).with(user) {@email}
           user.check_daily_requests
         end
 
         it 'should not send an email if the user has past 90%' do
-          user.attributes = {daily_requests: 90, updated_at: Time.now, max_requests: 100}
+          user.attributes = {daily_requests: 90, updated_at: Time.zone.now, max_requests: 100}
           expect(SupplejackApi::RequestLimitMailer).to_not receive(:at90percent).with(user) {@email}
           user.check_daily_requests
         end
 
         it 'should send an email if the user has reached 100%' do
           expect(@email).to receive(:deliver_now)
-          user.attributes = {daily_requests: 99, updated_at: Time.now, max_requests: 100}
+          user.attributes = {daily_requests: 99, updated_at: Time.zone.now, max_requests: 100}
           expect(SupplejackApi::RequestLimitMailer).to receive(:at100percent).with(user) {@email}
           user.check_daily_requests
         end
 
         it 'should not send an email when the user has past 100%' do
-          user.attributes = {daily_requests: 100, updated_at: Time.now, max_requests: 100}
+          user.attributes = {daily_requests: 100, updated_at: Time.zone.now, max_requests: 100}
           expect(SupplejackApi::RequestLimitMailer).to_not receive(:at100percent).with(user) {@email}
           user.check_daily_requests
         end
@@ -126,13 +126,13 @@ module SupplejackApi
 
     describe '#increment_daily_requests' do
       it 'should increment daily_requests by 1' do
-        user.attributes = { updated_at: Time.now, daily_requests: 100 }
+        user.attributes = { updated_at: Time.zone.now, daily_requests: 100 }
         user.increment_daily_requests
         expect(user.daily_requests).to eq 101
       end
 
       it 'increments daily requests when is nil' do
-        user.attributes = { updated_at: Time.now, daily_requests: nil }
+        user.attributes = { updated_at: Time.zone.now, daily_requests: nil }
         user.increment_daily_requests
         expect(user.daily_requests).to eq 1
       end
@@ -223,7 +223,7 @@ module SupplejackApi
     describe '#over_limit?' do
       context 'user was updated today' do
         before(:each) do
-          user.updated_at = Time.now
+          user.updated_at = Time.zone.now
         end
 
         it 'should return true when daily requests is greater than max requests' do
@@ -239,7 +239,7 @@ module SupplejackApi
 
       context "user wasn't updated today" do
         it 'should always return false' do
-          user.attributes = {updated_at: Time.now-1.day, daily_requests: 100, max_requests: 99}
+          user.attributes = {updated_at: Time.zone.now-1.day, daily_requests: 100, max_requests: 99}
           expect(user.over_limit?).to be_falsey
         end
       end
@@ -247,15 +247,15 @@ module SupplejackApi
 
     describe '#calculate_last_30_days_requests' do
       let!(:user) { FactoryBot.create(:user) }
-      let!(:user_activity) { FactoryBot.create(:user_activity, user_id: user.id, total: 5, created_at: Time.now) }
+      let!(:user_activity) { FactoryBot.create(:user_activity, user_id: user.id, total: 5, created_at: Time.zone.now) }
 
       it 'adds up the totals of the last 30 days' do
-        FactoryBot.create(:user_activity, user_id: user.id, total: 2, created_at: Time.now - 5.days)
+        FactoryBot.create(:user_activity, user_id: user.id, total: 2, created_at: Time.zone.now - 5.days)
         expect(user.calculate_last_30_days_requests).to eq 7
       end
 
       it 'ignores requests older than 30 days' do
-        FactoryBot.create(:user_activity, user_id: user.id, total: 2, created_at: Time.now - 31.days)
+        FactoryBot.create(:user_activity, user_id: user.id, total: 2, created_at: Time.zone.now - 31.days)
         expect(user.calculate_last_30_days_requests).to eq 5
       end
 
@@ -269,8 +269,8 @@ module SupplejackApi
       let!(:user) { FactoryBot.create(:user) }
 
       before do
-        FactoryBot.create(:user_activity, user_id: user.id, total: 5, created_at: Time.now - 1.day)
-        FactoryBot.create(:user_activity, user_id: user.id, total: 2, created_at: Time.now)
+        FactoryBot.create(:user_activity, user_id: user.id, total: 5, created_at: Time.zone.now - 1.day)
+        FactoryBot.create(:user_activity, user_id: user.id, total: 2, created_at: Time.zone.now)
       end
 
       it 'returns an array with the total requests per day' do
@@ -278,7 +278,7 @@ module SupplejackApi
       end
 
       it "returns 0 for days when there isn't any activity" do
-        FactoryBot.create(:user_activity, user_id: user.id, total: 1, created_at: Time.now - 3.day)
+        FactoryBot.create(:user_activity, user_id: user.id, total: 1, created_at: Time.zone.now - 3.day)
         expect(user.requests_per_day(4)).to eq [1, 0, 5, 2]
       end
     end


### PR DESCRIPTION
Acceptance Criteria
===================

**Acceptance Criteria**
- Issues identified by the EFK alerts are resolved
- EFK is not reporting API pod errors

**Notes**
https://digitalnz.slack.com/archives/CK2F61ZP0/p1572465959072600
EFKAPP 9:05 AM
Unexpected container state
Monitor Unexpected container state just entered alert status. Please investigate the issue.
- Affected pods:
  - [production] api-sidekiq-b684df7c-zb6bq - CrashLoopBackOff
  - [production] lending-services-inquiries-submit-1572465600-tpqm6 - Error
  - [production] lending-services-inquiries-submit-1572465600-tpqm6 - CrashLoopBackOff
  - [production] api-request-metrics-summarize-1572465600-qs2pw - Error
  - [production] api-index-remaining-records-in-queue-1572465600-6fz6c - CrashLoopBackOff
  - [production] lending-services-inquiries-submit-1572465600-tpqm6 - CrashLoopBackOff
  - [production] api-interaction-metrics-worker-1572465600-kll8h - CrashLoopBackOff
  - [production] api-interaction-metrics-worker-1572465600-kll8h - Error
  - [production] api-index-remaining-records-in-queue-1572465600-nc2g8 - CrashLoopBackOff
  - [production] api-interaction-metrics-worker-1572465600-kll8h - CrashLoopBackOff


Background
==========

- fixed the batch_index_records.rb