### PR TITLE
Date.current and Date.today are not using UTC...

### DIFF
--- a/app/models/supplejack_api/interaction_updaters/set_metrics.rb
+++ b/app/models/supplejack_api/interaction_updaters/set_metrics.rb
@@ -16,10 +16,10 @@ module SupplejackApi
 
         unique_facets.each do |facet|
           metric = SupplejackApi::UsageMetrics.find_or_create_by(
-            date: Date.current,
+            date: Time.now.utc.to_date,
             record_field_value: facet
           ) do |um|
-            um.date = Date.current
+            um.date = Time.now.utc.to_date
             um.record_field_value = facet
           end
 

--- a/app/models/supplejack_api/interaction_updaters/usage_metrics.rb
+++ b/app/models/supplejack_api/interaction_updaters/usage_metrics.rb
@@ -31,10 +31,10 @@ module SupplejackApi
 
       def process_facet(facet, search_counts, get_counts, user_set_counts)
         usage_metric_entry = SupplejackApi::UsageMetrics.find_or_create_by(
-          date: Date.current,
+          date: Time.now.utc.to_date,
           record_field_value: facet
         ) do |metric|
-          metric.date = Date.current
+          metric.date = Time.now.utc.to_date
           metric.record_field_value = facet
         end
 

--- a/app/models/supplejack_api/user.rb
+++ b/app/models/supplejack_api/user.rb
@@ -163,7 +163,7 @@ module SupplejackApi
       date = today - days.days
       while date < today
         date += 1.day
-        requests << (user_activities.find { |ua| ua.created_at.to_date == date }.try(:total) || 0)
+        requests << (user_activities.find { |ua| ua.created_at.utc.to_date == date }&.total || 0)
       end
       requests
     end

--- a/app/services/metrics_api/v3/endpoints/root.rb
+++ b/app/services/metrics_api/v3/endpoints/root.rb
@@ -26,8 +26,8 @@ module MetricsApi
 
         def initialize(params)
           @facets = parse_csv_param(params[:facets])
-          @start_date = parse_date_param(params[:start_date]) || Date.yesterday
-          @end_date = parse_date_param(params[:end_date]) || Date.yesterday
+          @start_date = parse_date_param(params[:start_date]) || Time.now.utc.yesterday.to_date
+          @end_date = parse_date_param(params[:end_date]) || Time.now.utc.yesterday.to_date
           @metrics = parse_csv_param(params[:metrics]) || %w[record view]
         end
 

--- a/app/workers/supplejack_api/daily_metrics_worker.rb
+++ b/app/workers/supplejack_api/daily_metrics_worker.rb
@@ -47,7 +47,7 @@ module SupplejackApi
 
       {
         name: facet,
-        date: Date.current,
+        date: Time.now.utc.to_date,
         total_active_records: s.total,
         total_new_records: 0
       }.merge(facet_metadata)
@@ -55,7 +55,7 @@ module SupplejackApi
 
     def update_total_new_records(facets)
       facets = facets.dup
-      records = SupplejackApi.config.record_class.active.created_on(Date.current)
+      records = SupplejackApi.config.record_class.active.created_on(Time.now.utc.to_date)
       counts_grouped_by_primary_key = records.group_by(&primary_key.to_sym).map { |k, v| [k, v.length] }
 
       counts_grouped_by_primary_key.each do |primary_key, count|
@@ -76,7 +76,7 @@ module SupplejackApi
 
       active_records = SupplejackApi.config.record_class.active
       total_records = active_records.count
-      total_new_records = active_records.created_on(Date.current).count
+      total_new_records = active_records.created_on(Time.now.utc.to_date).count
       total_copyright_counts = facets.map { |x| x[:copyright_counts] }.reduce({}, &merge_block)
       total_category_counts = facets.map { |x| x[:category_counts] }.reduce({}, &merge_block)
 
@@ -96,7 +96,7 @@ module SupplejackApi
       public_user_sets_count = SupplejackApi::UserSet.publicly_viewable.excluding_favorites.count
 
       DailyMetrics.create(
-        date: Date.current,
+        date: Time.now.utc.to_date,
         total_public_sets: public_user_sets_count
       )
     end

--- a/spec/controllers/supplejack_api/harvester/sources_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/sources_controller_spec.rb
@@ -69,7 +69,7 @@ module SupplejackApi
 
         context 'limit and order sources' do
           before do
-            FactoryBot.create_list(:source, 11, status: 'active', status_updated_at: Faker::Date.between(2.days.ago.utc, Date.today))
+            FactoryBot.create_list(:source, 11, status: 'active', status_updated_at: Faker::Date.between(2.days.ago.utc.to_date, Time.now.utc.to_date))
             FactoryBot.create_list(:source, 5, status: 'suppressed')
           end
 

--- a/spec/controllers/supplejack_api/metrics_api_controller_spec.rb
+++ b/spec/controllers/supplejack_api/metrics_api_controller_spec.rb
@@ -6,9 +6,9 @@ module SupplejackApi
 
     def build_models
       5.times do |n|
-        create(:daily_item_metric, date: Date.current - n.days)
-        create(:faceted_metrics, date: Date.current - n.days)
-        create(:collection_metric, created_at: Date.current - n.days)
+        create(:daily_item_metric, date: Time.now.utc.to_date - n.days)
+        create(:faceted_metrics, date: Time.now.utc.to_date - n.days)
+        create(:collection_metric, created_at: Time.now.utc.to_date - n.days)
       end
     end
 
@@ -19,12 +19,12 @@ module SupplejackApi
         end
 
         it 'retrieves a range of extended metrics, filtered against the facet parameter' do
-          create(:faceted_metrics, name: 'dc1', date: Date.yesterday)
-          create(:faceted_metrics, name: 'dc2', date: Date.yesterday)
-          create(:collection_metric, display_collection: 'dc1', date: Date.yesterday)
-          create(:collection_metric, date: Date.yesterday)
+          create(:faceted_metrics, name: 'dc1', date: Time.now.utc.yesterday.to_date)
+          create(:faceted_metrics, name: 'dc2', date: Time.now.utc.yesterday.to_date)
+          create(:collection_metric, display_collection: 'dc1', date: Time.now.utc.yesterday.to_date)
+          create(:collection_metric, date: Time.now.utc.yesterday.to_date)
 
-          get :root, params: { version: 'v3', facets: 'dc1', start_date: Date.yesterday, end_date: Date.yesterday }
+          get :root, params: { version: 'v3', facets: 'dc1', start_date: Time.now.utc.yesterday.to_date, end_date: Time.now.utc.yesterday.to_date }
           json = JSON.parse(response.body)
 
           expect(json.first['record'].count).to eq(1)

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -4,7 +4,7 @@ module SupplejackApi
   FactoryBot.define do
     factory :activity, class: SiteActivity do
       created_at 1.day.ago.utc
-      updated_at Date.today
+      updated_at Time.now.utc.to_date
       date       { Faker::Date.birthday(18, 65) }
       user_sets 1264
       search    696979

--- a/spec/factories/daily_metrics.rb
+++ b/spec/factories/daily_metrics.rb
@@ -4,7 +4,7 @@ module SupplejackApi
   FactoryBot.define do
     factory :daily_metrics, class: SupplejackApi::DailyMetrics do
       total_public_sets 10
-      date              {Date.current}
+      date              {Time.now.utc.to_date}
     end
   end
 end

--- a/spec/factories/faceted_metrics.rb
+++ b/spec/factories/faceted_metrics.rb
@@ -3,7 +3,7 @@ require 'faker'
 module SupplejackApi
   FactoryBot.define do
     factory :faceted_metrics, class: SupplejackApi::FacetedMetrics do
-      date {Date.current}
+      date {Time.now.utc.to_date}
       total_active_records 10
       total_new_records 1
       sequence(:name) {|n| "Display collection #{n}"}
@@ -14,7 +14,7 @@ module SupplejackApi
         }
       end
 
-      copyright_counts do 
+      copyright_counts do
         {
           'copyright-1' => 1,
           'copyright-2' => 2

--- a/spec/factories/usage_metrics.rb
+++ b/spec/factories/usage_metrics.rb
@@ -8,7 +8,7 @@ module SupplejackApi
 			user_set_views             1
 			total_views                1
       records_added_to_user_sets 1
-      date                       Date.current
+      date                       Time.now.utc.to_date
     end
   end
 end

--- a/spec/models/site_activity_spec.rb
+++ b/spec/models/site_activity_spec.rb
@@ -9,8 +9,8 @@ module SupplejackApi
 
     context 'validations' do
       it 'should be invalid when there is a existing site_activity with the same date' do
-        SupplejackApi::SiteActivity.create(date: Date.today)
-        expect(SupplejackApi::SiteActivity.new(date: Date.today)).to_not be_valid
+        SupplejackApi::SiteActivity.create(date: Time.now.utc.to_date)
+        expect(SupplejackApi::SiteActivity.new(date: Time.now.utc.to_date)).to_not be_valid
       end
     end
 

--- a/spec/models/supplejack_api/interaction_updaters/all_usage_metric_spec.rb
+++ b/spec/models/supplejack_api/interaction_updaters/all_usage_metric_spec.rb
@@ -30,10 +30,10 @@ module SupplejackApi
       end
 
       it 'does not process UsageMetrics created in the past' do
-        create(:usage_metrics, date: Date.yesterday)
+        create(:usage_metrics, date: Time.now.utc.yesterday.to_date)
 
         updater.process
-        
+
         expect(all_usage_metric.searches).to eq(2)
       end
     end

--- a/spec/models/supplejack_api/interaction_updaters/set_metrics_spec.rb
+++ b/spec/models/supplejack_api/interaction_updaters/set_metrics_spec.rb
@@ -13,7 +13,7 @@ module SupplejackApi
 
       it 'takes an array of Set interactions and creates a UsageMetrics model' do
         updater.process(@set_interactions)
-        metric = SupplejackApi::UsageMetrics.first 
+        metric = SupplejackApi::UsageMetrics.first
 
         expect(metric).to be_present
         expect(metric.record_field_value).to eq('test1')
@@ -21,7 +21,7 @@ module SupplejackApi
       end
 
       it 'updates an existing UsageMetrics model if one exists' do
-        create(:usage_metrics, record_field_value: 'test1', records_added_to_user_sets: 2, date: Date.current)
+        create(:usage_metrics, record_field_value: 'test1', records_added_to_user_sets: 2, date: Time.now.utc.to_date)
         updater.process(@set_interactions)
         metric = SupplejackApi::UsageMetrics.first
 

--- a/spec/models/supplejack_api/interaction_updaters/usage_metrics_spec.rb
+++ b/spec/models/supplejack_api/interaction_updaters/usage_metrics_spec.rb
@@ -13,7 +13,7 @@ module SupplejackApi
 
       it 'takes an array of Record interactions and creates a UsageMetrics model' do
         updater.process(@request_logs)
-        metric = SupplejackApi::UsageMetrics.first 
+        metric = SupplejackApi::UsageMetrics.first
 
         expect(metric).to be_present
         expect(metric.record_field_value).to eq('test')
@@ -23,13 +23,13 @@ module SupplejackApi
       end
 
       it 'updates an existing UsageMetrics model if one exists' do
-        create(:usage_metrics, 
-          record_field_value: 'test', 
-          searches: 1, 
-          gets: 1, 
-          user_set_views: 1, 
-          total_views: 3, 
-          date: Date.current
+        create(:usage_metrics,
+          record_field_value: 'test',
+          searches: 1,
+          gets: 1,
+          user_set_views: 1,
+          total_views: 3,
+          date: Time.now.utc.to_date
         )
         updater.process(@request_logs)
         metric = SupplejackApi::UsageMetrics.first

--- a/spec/models/supplejack_api/request_metric_spec.rb
+++ b/spec/models/supplejack_api/request_metric_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe SupplejackApi::RequestMetric do
 
   describe '#summarize' do
 
-    let!(:appeared_in_searches_yesterday) { create_list(:request_metric, 5, date: 1.day.ago.utc) }
-    let!(:user_set_views_yesterday) { create_list(:request_metric, 5, metric: 'user_set_views', date: 1.day.ago.utc) }
-    let!(:source_clickthroughs_yesterday) { create_list(:request_metric, 5, metric: 'source_clickthroughs', date: 1.day.ago.utc) }
+    let!(:appeared_in_searches_yesterday) { create_list(:request_metric, 5, date: 1.day.ago.utc.to_date) }
+    let!(:user_set_views_yesterday) { create_list(:request_metric, 5, metric: 'user_set_views', date: 1.day.ago.utc.to_date) }
+    let!(:source_clickthroughs_yesterday) { create_list(:request_metric, 5, metric: 'source_clickthroughs', date: 1.day.ago.utc.to_date) }
 
     let!(:appeared_in_searches_today) { create_list(:request_metric, 5) }
     let!(:user_set_views_today) { create_list(:request_metric, 5, metric: 'user_set_views') }
@@ -38,15 +38,15 @@ RSpec.describe SupplejackApi::RequestMetric do
 
       expect(SupplejackApi::RecordMetric.count).to eq 8
 
-      yesterday_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: 1.day.ago.utc)
-      yesterday_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: 1.day.ago.utc)
-      yesterday_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: 1.day.ago.utc)
-      yesterday_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: 1.day.ago.utc)
+      yesterday_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: 1.day.ago.utc.to_date)
+      yesterday_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: 1.day.ago.utc.to_date)
+      yesterday_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: 1.day.ago.utc.to_date)
+      yesterday_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: 1.day.ago.utc.to_date)
 
-      today_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: Time.now.utc)
-      today_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: Time.now.utc)
-      today_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: Time.now.utc)
-      today_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: Time.now.utc)
+      today_summed_1001 = SupplejackApi::RecordMetric.find_by(record_id: 1001, date: Time.now.utc.to_date)
+      today_summed_289 = SupplejackApi::RecordMetric.find_by(record_id: 289, date: Time.now.utc.to_date)
+      today_summed_30 = SupplejackApi::RecordMetric.find_by(record_id: 30, date: Time.now.utc.to_date)
+      today_summed_411 = SupplejackApi::RecordMetric.find_by(record_id: 411, date: Time.now.utc.to_date)
 
       expect(yesterday_summed_1001.appeared_in_searches).to eq 5
       expect(yesterday_summed_289.appeared_in_searches).to eq 10

--- a/spec/services/metrics_api/v3/api_spec.rb
+++ b/spec/services/metrics_api/v3/api_spec.rb
@@ -6,15 +6,15 @@ module MetricsApi
       let!(:daily_item_metric){create(:daily_item_metric)}
       let(:api) do
         Api.new({
-          start_date: @start_date, 
-          end_date: @end_date, 
+          start_date: @start_date,
+          end_date: @end_date,
           metrics: "usage,display_collection"
         })
       end
 
       before do
-        @start_date = Date.current
-        @end_date = Date.current
+        @start_date = Time.now.utc.to_date
+        @end_date = Time.now.utc.to_date
 
         5.times.map{create(:usage_metrics)}
       end

--- a/spec/services/metrics_api/v3/endpoints/global_spec.rb
+++ b/spec/services/metrics_api/v3/endpoints/global_spec.rb
@@ -8,10 +8,10 @@ module MetricsApi
 
         describe "#call" do
           it "returns an array of hashes representing the DailyMetrics for the supplied date range" do
-            create(:daily_metrics, date: Date.today, total_public_sets: 10)
+            create(:daily_metrics, date: Time.now.utc.to_date, total_public_sets: 10)
 
             expect(global.call).to eq([{
-              day: Date.today,
+              day: Time.now.utc.to_date,
               total_public_sets: 10
             }])
           end

--- a/spec/services/metrics_api/v3/endpoints/root_spec.rb
+++ b/spec/services/metrics_api/v3/endpoints/root_spec.rb
@@ -16,21 +16,21 @@ module MetricsApi
         context 'Metrics' do
           before do
             @facets = 'dc1,dc2'
-            @start_date = Date.current.strftime
-            @end_date = Date.current.strftime
+            @start_date = Time.now.utc.to_date.strftime
+            @end_date = Time.now.utc.to_date.strftime
             @metrics = 'view,record'
 
             create(:faceted_metrics, name: 'dc1')
             create(:faceted_metrics, name: 'dc2')
-            create(:collection_metric, display_collection: 'dc1', created_at: Date.current.midday, date: Time.now.utc.to_date)
-            create(:collection_metric, display_collection: 'dc2', created_at: Date.current.midday, date: Time.now.utc.to_date)
+            create(:collection_metric, display_collection: 'dc1', created_at: Time.now.utc.to_date.midday, date: Time.now.utc.to_date)
+            create(:collection_metric, display_collection: 'dc2', created_at: Time.now.utc.to_date.midday, date: Time.now.utc.to_date)
           end
 
           describe '#call' do
             it 'retrieves a range of metrics' do
               result = extended.call
 
-              expect(result.first[:date]).to eq(Date.current)
+              expect(result.first[:date]).to eq(Time.now.utc.to_date)
               expect(result.first['record'].length).to eq(2)
               expect(result.first['view'].length).to eq(2)
             end
@@ -39,7 +39,7 @@ module MetricsApi
               @facets = 'dc1'
               result = extended.call
 
-              expect(result.first[:date]).to eq(Date.current)
+              expect(result.first[:date]).to eq(Time.now.utc.to_date)
               expect(result.first['record'].length).to eq(1)
               expect(result.first['view'].length).to eq(1)
             end

--- a/spec/services/metrics_api/v3/presenters/extended_metadata_spec.rb
+++ b/spec/services/metrics_api/v3/presenters/extended_metadata_spec.rb
@@ -4,40 +4,40 @@ module MetricsApi
   module V3
     module Presenters
       describe ExtendedMetadata do
-        let(:presenter){ExtendedMetadata.new(@models, Date.yesterday, Date.current)}
+        let(:presenter){ExtendedMetadata.new(@models, Time.now.utc.yesterday.to_date, Time.now.utc.to_date)}
 
         before do
           @models = [
             {
               metric: 'view',
               models: {
-                Date.current => [
+                Time.now.utc.to_date => [
                   create(:collection_metric, dc: 'test1'),
                   create(:collection_metric, dc: 'test2')
                 ],
-                Date.yesterday => [
-                  create(:collection_metric, created_at: Date.yesterday.midday)
+                Time.now.utc.yesterday.to_date => [
+                  create(:collection_metric, created_at: Time.now.utc.yesterday.to_date.midday)
                 ]
               }
             },
             {
               metric: 'record',
               models: {
-                Date.current => [
+                Time.now.utc.to_date => [
                   create(:faceted_metrics),
                 ],
-                Date.yesterday => [
-                  create(:faceted_metrics, date: Date.yesterday)
+                Time.now.utc.yesterday.to_date => [
+                  create(:faceted_metrics, date: Time.now.utc.yesterday.to_date)
                 ]
               }
             },
             {
               metric: 'top_records',
               models: {
-                Date.current => [
+                Time.now.utc.to_date => [
                   create(:top_collection_metric, results: { 123 => 456, 345 => 678}, date: Time.now.utc.to_date),
                 ],
-                Date.yesterday => [
+                Time.now.utc.yesterday.to_date => [
                   create(:top_collection_metric, results: { 910 => 123, 456 => 789}, date: Time.now.utc.yesterday)
                 ]
               }
@@ -49,8 +49,8 @@ module MetricsApi
           json = presenter.to_json
 
           expect(json.length).to eq(2)
-          expect(json.first[:date]).to eq(Date.yesterday)
-          expect(json.last[:date]).to eq(Date.current)
+          expect(json.first[:date]).to eq(Time.now.utc.yesterday.to_date)
+          expect(json.last[:date]).to eq(Time.now.utc.to_date)
           expect(json.first['record'].length).to eq(1)
           expect(json.first['view'].length).to eq(1)
           expect(json.first['top_records'].length).to eq(1)

--- a/spec/workers/supplejack_api/daily_metrics_worker_spec.rb
+++ b/spec/workers/supplejack_api/daily_metrics_worker_spec.rb
@@ -16,9 +16,9 @@ module SupplejackApi
     describe "#call" do
       def build_records
         10.times do
-          create(:record_with_fragment, display_collection: 'pc1', copyright: ['0'],      category: ['0'], created_at: Date.current.midday)
-          create(:record_with_fragment, display_collection: 'pc2', copyright: ['1'],      category: ['1'], created_at: Date.current.midday)
-          create(:record_with_fragment, display_collection: 'pc1', copyright: ['0', '1'], category: ['0', '1'], created_at: Date.yesterday.midday)
+          create(:record_with_fragment, display_collection: 'pc1', copyright: ['0'],      category: ['0'], created_at: Time.now.utc.to_date.midday)
+          create(:record_with_fragment, display_collection: 'pc2', copyright: ['1'],      category: ['1'], created_at: Time.now.utc.to_date.midday)
+          create(:record_with_fragment, display_collection: 'pc1', copyright: ['0', '1'], category: ['0', '1'], created_at: Time.now.utc.yesterday.to_date.midday)
         end
 
         Sunspot.commit
@@ -33,7 +33,7 @@ module SupplejackApi
       it "handles records with missing categories/copyrights" do
         10.times do |n|
           c = n % 2 == 0 ? nil : ['0']
-          create(:record_with_fragment, created_at: Date.current.midday, copyright: c)
+          create(:record_with_fragment, created_at: Time.now.utc.to_date.midday, copyright: c)
         end
         Sunspot.commit
 
@@ -48,7 +48,7 @@ module SupplejackApi
         Sunspot.commit
 
         DailyMetricsWorker.new.call
-        expect(FacetedMetrics.created_on(Date.current).first.copyright_counts.first.first).to eq("1.0")
+        expect(FacetedMetrics.created_on(Time.now.utc.to_date).first.copyright_counts.first.first).to eq("1.0")
       end
 
       it "correctly paginates the facet list when there are more than 150 facets" do
@@ -93,7 +93,7 @@ module SupplejackApi
 
         it "creates an All facet that contains the summed metrics of for all the individual facets" do
           all_metric = SupplejackApi::FacetedMetrics.where(name: 'all').first
-          
+
           expect(all_metric.total_active_records).to eq(30)
           expect(all_metric.total_new_records).to eq(20)
           expect(all_metric.copyright_counts['0']).to eq(20)
@@ -113,7 +113,7 @@ module SupplejackApi
         end
 
         it 'sets the date field to the current day' do
-          expect(metric.date).to eq(Date.current)
+          expect(metric.date).to eq(Time.now.utc.to_date)
         end
 
         context "set metrics" do


### PR DESCRIPTION
if you are in NZT which is 12 hours ahead of UTC and do something like this:
Date.today < MyObject.created_at.utc.to_date
Date.today would be 2019-03-02 because it's using NZT but created_at will be
2019-03-01 and we don't get the result we expect.

So the idea is to avoid to use the Date object