### PR TITLE
BUG: Deleted stories aren't being removed from search results

### DIFF
--- a/app/services/stories_api/v3/endpoints/story.rb
+++ b/app/services/stories_api/v3/endpoints/story.rb
@@ -52,7 +52,7 @@ module StoriesApi
 
           return create_error('StoryNotFound', id: params[:id]) if story.blank?
 
-          story.delete
+          story.destroy
 
           create_response(status: 204)
         end


### PR DESCRIPTION
[BUG: Deleted stories aren't being removed from search results](https://www.pivotaltracker.com/story/show/173004685)

STORY
=====

**Note**
- Can you double check if there is a dnz record associated in Mongo. It shouldnt be in solr, but it could still be hanging around in mongo.


https://boost.sifterapp.com/issues/8957

A user alerted us to the fact that a number of stories that she had deleted were still showing up in search results.

This story (https://digitalnz.org/stories/5d0e075612575731faff59fc) five generations has been deleted but it is the first result on the stories tab on the key word search generations: https://digitalnz.org/records?text=generations&tab=Stories

Also, this story (https://digitalnz.org/stories/5e54cff24d3bb7000789e058) Dressed for work! has been deleted, but it similarly shows up in search results: https://digitalnz.org/records?text=dressed&tab=Stories

Is there a more general issue here?
I.e. let's not just fix these particular stories if there is an issue with the deletion feature

WHAT WAS DONE
==============

- calling destroy instead of delete triggers the callbacks deleting the solr record