### PR TITLE
CONSOLIDATE KUBERNETES SECRETS: As Richard, I want common Kubernetes secrets consolidated, so that they are easy to manage in the event of a disaster.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,7 +426,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     yard (0.9.20)
 
 PLATFORMS

--- a/spec/dummy/config/application.yml
+++ b/spec/dummy/config/application.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   DEVISE_MAILER: 'mailer@example.com'
   HARVESTER_IPS: '127.0.0.1'
   REQUEST_LIMIT_MAILER: 'develop@example.com'
-  MONGOID_HOSTS: 'localhost:27017'
+  MONGO_HOSTS: 'localhost:27017'
   WWW_DOMAIN: 'www.dev'
   REDIS_URL: 'redis://localhost:6379/1'
 

--- a/spec/dummy/config/application.yml.example
+++ b/spec/dummy/config/application.yml.example
@@ -13,7 +13,7 @@ defaults: &defaults
   BLACKLIST_MAILER_TO: 'blacklist@mailer.com'
   BLACKLIST_MAILER_FROM: 'mailer@blacklist.org'
   HTTP_HOST: 'http://test.host'
-  MONGOID_HOSTS: 'localhost:27017'
+  MONGO_HOSTS: 'localhost:27017'
 
 development:
   <<: *defaults

--- a/spec/dummy/config/mongoid.travis.yml
+++ b/spec/dummy/config/mongoid.travis.yml
@@ -5,19 +5,19 @@ development:
     default:
       database: supplejack_api_development
       hosts:
-        <%= ENV['MONGOID_HOSTS'].gsub(/\s+/, "").split(',') %>
+        <%= ENV['MONGO_HOSTS'].gsub(/\s+/, "").split(',') %>
 
     strong:
       database: supplejack_api_development
       hosts:
-        <%= ENV['MONGOID_HOSTS'].gsub(/\s+/, "").split(',') %>
+        <%= ENV['MONGO_HOSTS'].gsub(/\s+/, "").split(',') %>
 
 test:
   clients:
     default:
       database: supplejack_api_test
       hosts:
-        <%= ENV['MONGOID_HOSTS'].gsub(/\s+/, "").split(',') %>
+        <%= ENV['MONGO_HOSTS'].gsub(/\s+/, "").split(',') %>
       options:
         read:
           mode: :nearest
@@ -25,7 +25,7 @@ test:
     strong:
       database: supplejack_api_test
       hosts:
-        <%= ENV['MONGOID_HOSTS'].gsub(/\s+/, "").split(',') %>
+        <%= ENV['MONGO_HOSTS'].gsub(/\s+/, "").split(',') %>
       options:
         read:
           mode: :nearest


### PR DESCRIPTION
[CONSOLIDATE KUBERNETES SECRETS: As Richard, I want common Kubernetes secrets consolidated, so that they are easy to manage in the event of a disaster.](https://www.pivotaltracker.com/story/show/172953231)

STORY
=====

**Acceptance Criteria**
- Common infrastructure secrets are moved from app-specific secrets into secrets that can be shared between many apps.
- Update DR plan to reflect new process.

**Notes**
- MySQL
- Mongo
- ElastiCache
- SMTP
- Mail Relay
- IAM users
- Secrets are per namespace (applied to mail relay)

WHAT WAS DONE
==============

- Fixed a CVE
- Aligned MONGO variables