### PR TITLE
Fix stories cover image

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -11,11 +11,11 @@ module SupplejackApi
 
         render json: { status: :success, record_id: @record.record_id }
       rescue StandardError => e
-        Rails.logger.error "Fail to process record #{@record}: #{e.inspect}"
+        Rails.logger.error "Fail to process record #{@record&.record_id}: #{e.inspect}"
         render json: {
           status: :failed, exception_class: e.class.to_s,
           message: e.message, backtrace: e.backtrace,
-          raw_data: @record.attributes, record_id: @record.try(:record_id)
+          raw_data: @record&.attributes, record_id: @record&.record_id
         }
       end
 

--- a/spec/factories/story_item.rb
+++ b/spec/factories/story_item.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sub_type 'heading'
     content {{value: 'foo', image_url: ('a'..'z').to_a.shuffle.join, display_collection: 'TAPHUI', category: ['Audio']}}
     meta {{size: 1}}
-    record_id { SecureRandom.random_number(1000000) }
+    record_id { record&.record_id.present? ? record.record_id : SecureRandom.random_number(1000000) }
 
     trait :script_value do
       content { { value: '<script>alert("test");<script>' } }


### PR DESCRIPTION
When a record is deleted, it is checked to see if this record is the cover of an `UserSet`s.

If so, the next highest priority, active Record's thumbnail is set as the new cover image for the set.

Note: A manual fix up need to be applied to existing broken sets.

```
CSV.open("broken-stories.csv", "wb") do |csv|
  csv << ["Story ID", "Record ID", "Broken Thumbnail"]

  SupplejackApi::UserSet.where(:cover_thumbnail.nin => ["", nil]).each do |user_set|
    set_item_records = SupplejackApi::Record.where(:record_id.in => user_set.set_items.map(&:record_id))

    cover_record = set_item_records.to_a.find do |record|
      record.large_thumbnail_url == user_set.cover_thumbnail
    end
    next if cover_record.nil? || cover_record.active?

    csv << [user_set.id, cover_record.record_id, user_set.cover_thumbnail]

    print '.'
  end
end; nil
```

```
broken_record_ids.each do |id|
  r = SupplejackApi::Record.find_by(record_id: id)
  r.status = 'temp'
  r.replace_stories_cover
  
  sleep 0.5
  print '.'
end; nil
```