### PR TITLE
BUG: Error on DailyMetricsWorker

### DIFF
--- a/app/workers/supplejack_api/daily_metrics_worker.rb
+++ b/app/workers/supplejack_api/daily_metrics_worker.rb
@@ -3,7 +3,7 @@
 module SupplejackApi
   class DailyMetricsWorker
     include Sidekiq::Worker
-    sidekiq_options queue: 'critical', retry: 1
+    sidekiq_options queue: 'critical', retry: 5
 
     attr_reader :primary_key, :secondary_keys
 


### PR DESCRIPTION
This is being caused by Solr timing out when the daily metrics worker is trying to calculate the number of new and total records. 