### PR TITLE
MltSerializer

### DIFF
--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module SupplejackApi
+  # rubocop:disable Metrics/ClassLength
   class RecordsController < SupplejackApplicationController
     include SupplejackApi::Concerns::RecordsControllerMetrics
     include ActionController::RequestForgeryProtection
@@ -74,12 +75,11 @@ module SupplejackApi
         minimum_term_frequency(params[:frequency] || 1)
       end
 
-      respond_with mlt.results, each_serializer: self.class.record_serializer_class, root: 'records', adapter: :json
+      respond_with mlt.results, each_serializer: self.class.mlt_serializer_class, root: 'records', adapter: :json
     end
 
     # This options are merged with the serializer options. Which will allow the serializer
     # to know which fields to render for a specific request
-    #
     def default_serializer_options
       default_options = {}
       @search ||= SupplejackApi::RecordSearch.new(all_params)
@@ -92,6 +92,10 @@ module SupplejackApi
       SearchSerializer
     end
 
+    def self.mlt_serializer_class
+      MltSerializer
+    end
+
     def self.record_serializer_class
       RecordSerializer
     end
@@ -99,9 +103,9 @@ module SupplejackApi
     private
 
     def mlt_fields
-      return [] unless params[:fields]
+      return [] unless params[:mlt_fields]
 
-      params[:fields].split(',').map { |field| field.strip.to_sym }
+      params[:mlt_fields].split(',').map { |field| field.strip.to_sym }
     end
 
     def set_concept_param
@@ -135,4 +139,5 @@ module SupplejackApi
       _render_to_body_with_renderer(options) || super
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/serializers/supplejack_api/mlt_serializer.rb
+++ b/app/serializers/supplejack_api/mlt_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  class MltSerializer < ActiveModel::Serializer
+    attribute :id
+
+    RecordSchema.fields.each do |name, definition|
+      if definition.search_value.present? && definition.store == false
+        attribute name do
+          definition.search_value.call(object)
+        end
+      else
+        attribute name do
+          object.public_send(name).nil? ? definition.default_value : object.public_send(name)
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/supplejack_api/mlt_seializer_spec.rb
+++ b/spec/serializers/supplejack_api/mlt_seializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module SupplejackApi
+  describe MltSerializer do
+    let(:record) { FactoryBot.create(:record_with_fragment) }
+    let(:serialized_record) { described_class.new(record).as_json }
+
+    it 'renders the id' do
+      expect(serialized_record).to have_key :id
+    end
+
+    describe 'it renders attributes based on your schema' do
+      RecordSchema.fields.each do |name, definition|
+        next if definition.store == false
+
+        it "renders the #{name} field" do
+          expect(serialized_record).to have_key name
+        end
+      end
+    end
+
+    it 'allows a field to be overriden by passing a block and setting store to false on the schema' do
+      expect(serialized_record[:block_example]).to eq 'Value of the block'
+    end
+
+    it 'falls back to the provided default value if its value is nil' do
+      expect(serialized_record[:default_example]).to eq 'Default value'
+    end
+
+    it 'returns a value from the record' do
+      expect(serialized_record[:title]).to eq record.title
+    end
+
+    it 'returns multi values correctly' do
+      expect(serialized_record[:children]).to eq ['Sally Doe', 'James Doe']
+    end
+  end
+end


### PR DESCRIPTION
We were using RecordSerializer for mlt results before.
But this serializer was designed for harvester and it exposes some internal fields.
New serializer MltSerializer created.

Param fields renamed to mlt_fields so that it wont get confused with fields param used in search api call.