### PR TITLE
OPEN SOURCE SJ THUMBNAIL SCHEMA FIX:

### DIFF
--- a/app/models/supplejack_api/concerns/record.rb
+++ b/app/models/supplejack_api/concerns/record.rb
@@ -119,6 +119,7 @@ module SupplejackApi::Concerns::Record
     end
 
     def replace_stories_cover
+      return unless RecordSchema.fields.include?(:thumbnail_url) && RecordSchema.fields.include?(:large_thumbnail_url)
       return if active?
 
       SupplejackApi::UserSet.where(

--- a/app/models/supplejack_api/concerns/record.rb
+++ b/app/models/supplejack_api/concerns/record.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module SupplejackApi::Concerns::Record
   extend ActiveSupport::Concern
 
@@ -146,3 +147,4 @@ module SupplejackApi::Concerns::Record
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
**Acceptance Criteria**
- The most recent version of SJ Engine does not break if you don't have thumbnail and large_thumbnail defined in your schema. 