### PR TITLE
INDEX FACET INTEGERS FIELDS AS STRINGS: As Dan, I want fields that we use for faceting to be treated as strings, so that faceting works correctly. 

### DIFF
--- a/app/models/supplejack_api/schema_definition.rb
+++ b/app/models/supplejack_api/schema_definition.rb
@@ -36,7 +36,7 @@ module SupplejackApi
         field = Field.new(name, options, &block)
         self.fields[name] = field
 
-        # This is so we have a string alternative of an integer field that can be used for facetting. 
+        # This is so we have a string alternative of an integer field that can be used for facetting.
         field(:string, "#{name}_str", options.merge(type: :string), &block) if type == :integer
       end
 

--- a/app/models/supplejack_api/schema_definition.rb
+++ b/app/models/supplejack_api/schema_definition.rb
@@ -35,6 +35,9 @@ module SupplejackApi
 
         field = Field.new(name, options, &block)
         self.fields[name] = field
+
+        # This is so we have a string alternative of an integer field that can be used for facetting. 
+        field(:string, "#{name}_str", options.merge(type: :string), &block) if type == :integer
       end
 
       def group(name, options = {}, &block)

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -308,7 +308,11 @@ module SupplejackApi
           end
 
           or_and_options.slice(*facet_list).each do |key, value|
-            facet(key.to_sym, exclude: with(key.to_sym, value), limit: facets_per_page, offset: facets_offset)
+            if value =~ /(.+)\*$/
+              facet(key.to_sym, exclude: with(key.to_sym).starting_with(Regexp.last_match(1)), limit: facets_per_page, offset: facets_offset)
+            else
+              facet(key.to_sym, exclude: with(key.to_sym, value), limit: facets_per_page, offset: facets_offset)
+            end
           end
         end
 

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -295,7 +295,7 @@ module SupplejackApi
         end
 
         if options[:exclude_filters_from_facets] == 'true'
-          or_and_options = {}.merge(options[:and]).merge(options[:or])
+          or_and_options = {}.merge(options[:and]).merge(options[:or]).symbolize_keys
 
           # This is to clean up any valid integer facets that have been requested
           # Through the filter options, so that they are treated as strings.

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -308,9 +308,7 @@ module SupplejackApi
           end
 
           or_and_options.slice(*facet_list).each do |key, value|
-            raise Exception, 'exclude_filters_from_facets does not allow nested (:and, :or)' if %i[or and].include? key
-
-            facet(key.to_sym, exclude: with(key.to_sym, value))
+            facet(key.to_sym, exclude: with(key.to_sym, value), limit: facets_per_page, offset: facets_offset)
           end
         end
 

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -315,8 +315,7 @@ module SupplejackApi
         paginate page: page, per_page: per_page
       end
 
-      @search_builder.build(&build_conditions) unless options[:exclude_filters_from_facets] == 'true'
-
+      @search_builder.build(&build_conditions)
       @search_builder
     end
     # rubocop:enable Metrics/AbcSize
@@ -434,7 +433,13 @@ module SupplejackApi
             end
           end
         else
-          Utils.call_block(self, &filter_values(key, conditions, current_operator))
+          if options[:exclude_filters_from_facets] == 'true'
+            if facet_list.exclude?(key.to_sym)
+              Utils.call_block(self, &filter_values(key, conditions, current_operator))
+            end
+          else
+            Utils.call_block(self, &filter_values(key, conditions, current_operator))
+          end
         end
       end
     end

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -219,7 +219,7 @@ module SupplejackApi
 
       @search_builder ||= Sunspot.new_search(SupplejackApi.config.record_class) do
         with(:record_type, record_type) unless options[:record_type] == 'all'
-        
+
         search_model.facet_list.each do |facet_name|
           facet(facet_name, limit: facets_per_page, offset: facets_offset)
         end
@@ -309,7 +309,8 @@ module SupplejackApi
 
           or_and_options.slice(*facet_list).each do |key, value|
             if value =~ /(.+)\*$/
-              facet(key.to_sym, exclude: with(key.to_sym).starting_with(Regexp.last_match(1)), limit: facets_per_page, offset: facets_offset)
+              facet(key.to_sym, exclude: with(key.to_sym).starting_with(Regexp.last_match(1)), limit: facets_per_page,
+                                offset: facets_offset)
             else
               facet(key.to_sym, exclude: with(key.to_sym, value), limit: facets_per_page, offset: facets_offset)
             end
@@ -438,9 +439,7 @@ module SupplejackApi
           end
         else
           if options[:exclude_filters_from_facets] == 'true'
-            if facet_list.exclude?(key.to_sym)
-              Utils.call_block(self, &filter_values(key, conditions, current_operator))
-            end
+            Utils.call_block(self, &filter_values(key, conditions, current_operator)) if facet_list.exclude?(key.to_sym)
           else
             Utils.call_block(self, &filter_values(key, conditions, current_operator))
           end

--- a/app/serializers/supplejack_api/search_serializer.rb
+++ b/app/serializers/supplejack_api/search_serializer.rb
@@ -44,7 +44,7 @@ module SupplejackApi
           { name: row.value, count: row.count }
         end
 
-        facets << { name: facet.name.to_s, values: values }
+        facets << { name: facet.name.to_s.gsub('_str', ''), values: values }
       end
     end
 
@@ -55,6 +55,8 @@ module SupplejackApi
         end
 
         facets[facet.name] = rows
+
+        facets[facet.name.to_s.gsub('_str', '')] = facets.delete(facet.name) if facet.name.to_s.include? '_str'
       end
     end
 

--- a/spec/dummy/app/supplejack_api/record_schema.rb
+++ b/spec/dummy/app/supplejack_api/record_schema.rb
@@ -1,5 +1,3 @@
-
-
 class RecordSchema
   include SupplejackApi::SupplejackSchema
 
@@ -14,7 +12,7 @@ class RecordSchema
   string    :email,        multi_value: true,     search_as: [:filter]
   string    :children,     multi_value: true
   string    :contact,      multi_value: true
-  integer   :age
+  integer   :age,                                 search_as: [:filter]
   datetime  :birth_date
   boolean   :nz_citizen,                          search_as: [:filter]
   string    :display_collection,                                search_as: [:filter, :fulltext],  namespace: :sj

--- a/spec/models/supplejack_api/record_search_spec.rb
+++ b/spec/models/supplejack_api/record_search_spec.rb
@@ -441,12 +441,6 @@ module SupplejackApi
           }
         end
 
-        it 'does not allow nested :and :or queries' do
-          @search.options[:and] = {name: 'John', or: {address: 'Wellington', and: {nz_citizen: 'true', email: 'john@test.com'}}}
-          @search.options[:facets] = 'name'
-          expect{@search.execute_solr_search}.to raise_exception('exclude_filters_from_facets does not allow nested (:and, :or)')
-        end
-
         it 'does not add additional facets into the search' do
           @search.options[:and] = {category: ['Audio'], subject: ['forest']}
           @search.options[:facets] = 'category'
@@ -498,6 +492,15 @@ module SupplejackApi
             category_filter = with(:category, ['Images'])
             facet(:category, :exclude => category_filter)
           } 
+        end
+
+        it 'applies filters that are given which are not facets' do
+          @search.options[:and] = {'category' => ['Images']}
+          @search.options[:facets] = 'subject'
+          @search.execute_solr_search
+          expect(@session).to have_search_params(:with, :category, ['Images'])
+          expect(@session).to have_search_params(:facet, :subject)
+          expect(@session).not_to have_search_params(:facet, :category)
         end
       end
     end

--- a/spec/models/supplejack_api/record_search_spec.rb
+++ b/spec/models/supplejack_api/record_search_spec.rb
@@ -488,6 +488,17 @@ module SupplejackApi
             facet(:age_str, :exclude => age_filter)
           }
         end
+
+        it 'applies filters that are given as strings via the URL correctly' do
+          @search.options[:and] = {'category' => ['Images']}
+          @search.options[:facets] = 'subject, category'
+          @search.execute_solr_search
+
+          expect(@session).to have_search_params(:facet) {
+            category_filter = with(:category, ['Images'])
+            facet(:category, :exclude => category_filter)
+          } 
+        end
       end
     end
   end

--- a/spec/models/supplejack_api/search_spec.rb
+++ b/spec/models/supplejack_api/search_spec.rb
@@ -62,6 +62,11 @@ module SupplejackApi
         @search.options[:facets] = 'name, address, other_facet'
         expect(@search.facet_list).to eq [:name, :address]
       end
+
+      it 'should return string versions of integer facets' do
+        @search.options[:facets] = 'age'
+        expect(@search.facet_list).to eq [:age_str]
+      end
     end
 
     describe '#facet_pivot_list' do
@@ -292,7 +297,6 @@ module SupplejackApi
 	      allow(@search).to receive(:solr_search_object).and_return({})
 	      expect(@search.something_missing).to be_nil
 	    end
-	  end
-
+    end
   end
 end


### PR DESCRIPTION
**Acceptance Criteria**
- Integer fields that are required for facetting work.

**Notes**
- Index must be re-built using new fields. Index should be we switched to different Solr instance once index built
- At the moment there is an issue where the facet counts are wrong. This coincides with when we changed the way we store facets to be using docValues. Removing the docValues causes any field that is using a *Point field in the schema to break when you are asking for facets. This is because Point Fields only support facetting through docValues. The idea now is to index a string and an integer version of these fields that are needed for facetting and then alter the way the searches are constructed to only ask for facet fields as strings. We will need to change the schema DSL to index both versions of this field, and the search builder to construct the appropriate facet query. The alternative is to use the deprecated *Trie field which doesn't feel like a good long term solution. 
