### PR TITLE
Fix - facet exclusions: correctly account for nested OR queries

### DIFF
--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -336,7 +336,7 @@ module SupplejackApi
 
       if value =~ wildcard_search_term_regex
         search_context.with(facet_name).starting_with(Regexp.last_match(1))
-      elsif value.class == Hash && value.key?(:or)
+      elsif value.is_a?(Hash) && value.key?(:or)
         search_context.with(facet_name, value[:or])
       else
         # Value is a non-wildcarded string, or an array


### PR DESCRIPTION
Follow-up to https://github.com/DigitalNZ/supplejack_api/pull/232.

`exclude_filters_from_facets` was not working correctly with nested OR queries, because the `elsif` condition meant to catch them was incorrect.
In fact, a nested OR query is not a `Hash`, but rather a `ActiveSupport::HashWithIndifferentAccess`.
Therefore it was failing the class check (but not in the test suite, since in there they are regular hashes).

Now, the `elsif` condition works correctly :)