### PR TITLE
StoryItemSerializer returning deleted record

### DIFF
--- a/app/serializers/supplejack_api/story_item_serializer.rb
+++ b/app/serializers/supplejack_api/story_item_serializer.rb
@@ -34,8 +34,13 @@ module SupplejackApi
         status: :status
       }
 
-      record_id = object[:content][:id]
+      # This is done as user_set and stories endpoints behaved differently
+      # and created content with :id and :record_id. So now we have to deal with both.
+      record_id = object[:content][:id] || object[:content][:record_id]
       record = SupplejackApi::Record.find_by(record_id: record_id) rescue nil
+
+      return {} unless record
+
       result = { id: record_id.to_i }
 
       record_fields.each do |name, field|

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -87,10 +87,10 @@ RSpec.describe 'Stories Endpoints', type: :request do
                     'position' => content.position,
                     'type' => content.type,
                     'sub_type' => content.sub_type,
-                    'content' => {'value' => content.content[:value],
-                                  'image_url' => content.content[:image_url],
-                                  'display_collection' => content.content[:display_collection],
-                                  'category' => content.content[:category] },
+                    'content' => { 'value' => content.content[:value],
+                                   'image_url' => content.content[:image_url],
+                                   'display_collection' => content.content[:display_collection],
+                                   'category' => content.content[:category] },
                     'meta' => {'size' => content.meta[:size], 'is_cover' => false } }
                 end
               }


### PR DESCRIPTION
The serialiser was fetching the wrong id from the content of a user set item. This is due to some old data organised differently. 

Fix: Fetch record_id from both possible keys in content