### PR TITLE
[meteor] INDEXING MISSING RECORDS: As Haki, I want indexing to work reliably, so that records dont go missing and solr is up to date with mongo

### DIFF
--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -10,7 +10,7 @@ class BatchIndexRecords
   end
 
   def call
-    Sunspot.index(records.to_a) if records.any?
+    Sunspot.index(records) if records.any?
 
     # update_all skips the callbacks.
     SupplejackApi::Record.where(:record_id.in => records.map(&:record_id))

--- a/app/services/batch_remove_records_from_index.rb
+++ b/app/services/batch_remove_records_from_index.rb
@@ -27,9 +27,10 @@ class BatchRemoveRecordsFromIndex
     records.each do |record|
       Rails.logger.info "BatchRemoveRecordsFromIndex - REMOVE INDEX: #{record}"
       Sunspot.remove record
-      record.update(index_updated: true, index_updated_at: Time.current)
+      record.set(index_updated: true, index_updated_at: Time.current)
     rescue StandardError => e
       Rails.logger.error "BatchRemoveRecordsFromIndex - Failed to remove: #{record.inspect} - #{e.message}"
+      record.set(index_updated: true, index_updated_at: Time.current)
     end
   end
 end

--- a/app/services/batch_remove_records_from_index.rb
+++ b/app/services/batch_remove_records_from_index.rb
@@ -10,7 +10,7 @@ class BatchRemoveRecordsFromIndex
   end
 
   def call
-    Sunspot.remove(records.to_a) if records.any?
+    Sunspot.remove(records) if records.any?
 
     SupplejackApi::Record.where(:record_id.in => records.map(&:record_id))
                          .update_all(index_updated: true, index_updated_at: Time.current)

--- a/lib/supplejack_api/index_processor.rb
+++ b/lib/supplejack_api/index_processor.rb
@@ -3,27 +3,29 @@
 module SupplejackApi
   class IndexProcessor
     # rubocop:disable Rails/Output
-    # rubocop:disable Layout/LineLength
     def call
       p 'Looking for records to index..' unless Rails.env.test?
 
       while SupplejackApi::Record.ready_for_indexing.where(status: 'active').count.positive?
-        p "There are #{SupplejackApi::Record.ready_for_indexing.where(status: 'active').count} records to be indexed.." unless Rails.env.test?
 
-        BatchIndexRecords.new(SupplejackApi::Record.ready_for_indexing.where(status: 'active').limit(500)).call
+        records = SupplejackApi::Record.ready_for_indexing.where(status: 'active').limit(500).to_a
+
+        p "There are #{records.count} records to be indexed.." unless Rails.env.test?
+
+        BatchIndexRecords.new(records).call
       end
 
       p 'Looking for records to remove..' unless Rails.env.test?
 
       while SupplejackApi::Record.ready_for_indexing.where(:status.ne => 'active').count.positive?
-        p "There are #{SupplejackApi::Record.ready_for_indexing.where(:status.ne => 'active').count} records to be removed from the index.." unless Rails.env.test?
 
-        BatchRemoveRecordsFromIndex.new(
-          SupplejackApi::Record.ready_for_indexing.where(:status.ne => 'active').limit(500)
-        ).call
+        records = SupplejackApi::Record.ready_for_indexing.where(:status.ne => 'active').limit(500).to_a
+
+        p "There are #{records.count} records to be removed from the index.." unless Rails.env.test?
+
+        BatchRemoveRecordsFromIndex.new(records).call
       end
     end
     # rubocop:enable Rails/Output
-    # rubocop:enable Layout/LineLength
   end
 end


### PR DESCRIPTION
**Acceptance Criteria**
- Every record that is harvested is indexed.

**To reproduce**
- [All records show here](https://api.staging.digitalnz.org/records.json?&api_key=v0aORgQAmQDSPtOJzMGI&without[tag]=testing&and%5Bprimary_collection%5D=Central%20Otago%20Memory%20Bank&fields=id,title,collection,tag&debug=true) without the tag "testing" (the tag field is empty)
- [Running this harvest](https://manager.digitalnz.org/parsers/53795dc5745448c689000004/versions/60d2950632d3fd0009f04fe7) adds "testing" to the tag field
- The first link should now show no results, but instead it shows the leftover/unindexed records that you can see do have the tag of "testing" (so harvesting worked but indexing didnt)
- You can repeat this with the version either side, removing or changing that tag.

**Notes**
- I harvested 1000ish records, they all had their metadata updated. But each time I ran the harvest, anywhere between 3 and a 3 hundred did not get indexed
- For some reason running a [manual re-index](https://manager.digitalnz.org/sources/53795da4745448f627000004/edit#) did seem to work in full every time
- First noticed 1st June. May have been around earlier?
- Problem is happening in staging and production


** Discovery **

When passing the Mongoid criteria, rather than an array of records themselves, there is a difference in evaluation between what get marked as indexed and what gets sent to Solr. This causes issues where in the database records are marked as indexed, but they aren't actually in Solr. 