### PR TITLE
SJ RECORD FRAGMENT VIEW: As Haki, I want to be able to check exactly how the metadata is stored in which fragments, so that I can see the truth of the record

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -55,11 +55,8 @@ module SupplejackApi
         @record = SupplejackApi.config.record_class.where(record_id: params[:id]).first
 
         if @record.present?
-          render json: {
-            record_id: @record.record_id,
-            title: @record.title,
-            status: @record.status
-          }.to_json
+          render json: @record,
+                 serializer: self.class.record_serializer_class
         else
           head :no_content
         end


### PR DESCRIPTION
[SJ RECORD FRAGMENT VIEW: As Haki, I want to be able to check exactly how the metadata is stored in which fragments, so that I can see the truth of the record](https://www.pivotaltracker.com/story/show/178369583)

STORY
=====

**Acceptance Criteria**
- SJ dumps raw json metadata as it is stored in Mongo (eg base of the record + fragments + merged fragments)
for a single record, on this page
https://manager.digitalnz.org/staging/collection_records?id=48928683&commit=Search+Record
- Remove bastion host and Dan's mongo access
- Remove Elastic IP assigner

**Notes**
- Info could come from old secret harvester API route available? 


WHAT WAS DONE
==============

- Used the record serializer for the record view