### PR TITLE
IMPROVE STORY ERROR HANDLING

### DIFF
--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -62,16 +62,7 @@ module SupplejackApi
     end
 
     def reposition_items
-      if params[:items].count == @story.set_items.count
-        params[:items].each do |item|
-          story_item = @story.set_items.find_by_id(item[:id])
-
-          next unless story_item
-
-          story_item.position = item[:position]
-          story_item.save(validate: false)
-        end
-
+      if @story.reposition_items(params[:items])
         head :ok
       else
         render json: { errors: I18n.t('errors.reposition_error') }, status: :bad_request

--- a/app/models/supplejack_api/user_set.rb
+++ b/app/models/supplejack_api/user_set.rb
@@ -331,6 +331,28 @@ module SupplejackApi
     def contents
       set_items
     end
+
+    # Repositioning is possible by sending all items ids OR all items ids + temporary item ids
+    # This is so that a new position space can be created for a future item
+    def can_reposition?(items)
+      set_item_ids = set_items.map { |item| item.id.to_s }
+      item_ids = items.map { |item| item[:id].to_s }
+
+      (set_item_ids - item_ids).empty?
+    end
+
+    def reposition_items(items)
+      return false unless can_reposition?(items)
+
+      items.each do |item|
+        story_item = set_items.find_by_id(item[:id])
+
+        next unless story_item
+
+        story_item.position = item[:position]
+        story_item.save(validate: false)
+      end
+    end
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/controllers/supplejack_api/stories_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories_controller_spec.rb
@@ -205,6 +205,34 @@ module SupplejackApi
         end
       end
 
+      context 'when an extra items is added to reposition list' do
+        before do
+          items = story.set_items
+          reposition_params = [
+            { id: items[0].id, position: 1 },
+            { id: items[1].id, position: 2 },
+            { id: 'temp:id', position: 3 },
+            { id: items[2].id, position: 4 }
+          ]
+
+          post :reposition_items,
+               params: { story_id: story.id.to_s, api_key: api_key, user_key: api_key, items: reposition_params }
+        end
+
+        it 'returns status ok' do
+          expect(response).to have_http_status :ok
+        end
+
+        it 'repositions story items' do
+          story.reload
+          items = story.set_items
+
+          expect(items[0].position).to eq 1
+          expect(items[1].position).to eq 2
+          expect(items[2].position).to eq 4
+        end
+      end
+
       context 'when not all items are repositioned' do
         before do
           items = story.set_items


### PR DESCRIPTION
**Issue**
When front end requires to create a position in between existing items, repositioning logic fails as the check requires exactly the same number of items as set items in the data base to be send to this action

**Fix**
All valid item ids + temporary item ids are permitted for repositioning

**Changes**
All logic moved to UserSet model