### PR TITLE
SJ CLIENT TO RETURN PROPER API ERROR MESSAGES: As SJ user, I want the client to return errors from the API so that I can communicate it with the frontend user.

### DIFF
--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -41,7 +41,7 @@ module SupplejackApi
         story.save!
         render json: StorySerializer.new(story, scope: { slim: false }).to_json(include_root: false), status: :created
       else
-        render_error_with(story.errors[:name], :bad_request)
+        render_error_with(story.errors.messages, :bad_request)
       end
     end
 
@@ -51,7 +51,7 @@ module SupplejackApi
       if @story.update(story_params)
         render json: StorySerializer.new(@story, scope: { slim: false }).to_json(include_root: false), status: :ok
       else
-        render_error_with('Failed to update', :bad_request)
+        render_error_with(@story.errors.messages, :bad_request)
       end
     end
 

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe 'Stories Endpoints', type: :request do
         it 'returns mandatory param error' do
           response_attributes = JSON.parse(response.body)
 
-          expect(response_attributes).to eq({ 'errors' => {"name"=>["Name field can't be blank."]} })
+          expect(response_attributes).to eq({ 'errors' => { 'name' => ["Name field can't be blank."] } })
         end
       end
     end

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe 'Stories Endpoints', type: :request do
         it 'returns mandatory param error' do
           response_attributes = JSON.parse(response.body)
 
-          expect(response_attributes).to eq({ 'errors' => ["Name field can't be blank."] })
+          expect(response_attributes).to eq({ 'errors' => {"name"=>["Name field can't be blank."]} })
         end
       end
     end


### PR DESCRIPTION
**Acceptance Criteria**
- SJ client methods return errors to the application and not just 400

**Notes**
- Related DNZ story 
https://www.pivotaltracker.com/story/show/179369096





