### PR TITLE
FIX METRICS DASHBOARD DATE QUERIES

### DIFF
--- a/app/models/supplejack_api/concerns/queryable_by_date.rb
+++ b/app/models/supplejack_api/concerns/queryable_by_date.rb
@@ -17,7 +17,8 @@ module SupplejackApi
         end
 
         def created_between(start_date, end_date)
-          where(:date.gte => start_date, :date.lte => end_date)
+          where(:date.gte => start_date.beginning_of_day.getutc,
+                :date.lte => end_date.end_of_day.getutc)
         end
       end
     end


### PR DESCRIPTION
**Issue**
- When date start date & end date is the same in the metrics API the query results are wrong. 
 - Attached the code from the console below. The first block is how we do it now in the API, the second block is how it should be done. This is the reason why `interactions` & `view and impressions` are 0 when landing on dashboard.
- When manually selected same date for start and end is not working on the form. The form appears to accept it but in the background sets end date as current date.

**Acceptance Criteria**
- Fix the bugs