### PR TITLE
ALLOW ANONYMOUS API REQUESTS: As James, I want to safely allow anonymous API requests, so that people can readily play with the API when we move API keys into the HTTP header

### DIFF
--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -35,12 +35,6 @@ module SupplejackApi
             render xml: serializable_resource.as_json.as_json.to_xml(root: 'search')
           end
           format.rss { respond_with @search }
-          format.html do
-            # fall back to prevent the page from crashing if the user goes to /
-            render json: @search, serializer: self.class.search_serializer_class, record_fields: available_fields,
-                   record_includes: available_fields, root: 'search', adapter: :json,
-                   callback: params['jsonp']
-          end
         end
       else
         render request.format.to_sym => { errors: @search.errors }, status: :bad_request

--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -35,6 +35,12 @@ module SupplejackApi
             render xml: serializable_resource.as_json.as_json.to_xml(root: 'search')
           end
           format.rss { respond_with @search }
+          format.html do
+            # fall back to prevent the page from crashing if the user goes to /
+            render json: @search, serializer: self.class.search_serializer_class, record_fields: available_fields,
+                   record_includes: available_fields, root: 'search', adapter: :json,
+                   callback: params['jsonp']
+          end
         end
       else
         render request.format.to_sym => { errors: @search.errors }, status: :bad_request

--- a/app/controllers/supplejack_api/set_items_controller.rb
+++ b/app/controllers/supplejack_api/set_items_controller.rb
@@ -4,6 +4,7 @@ module SupplejackApi
   class SetItemsController < SupplejackApplicationController
     include SupplejackApi::Concerns::UserSetsControllerMetrics
 
+    before_action :prevent_anonymous!
     before_action :find_user_set
 
     respond_to :json

--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -13,7 +13,6 @@ module SupplejackApi
     before_action :find_story, only: %i[show update destroy reposition_items]
     after_action :create_story_record_views, only: :show
 
-
     def index
       render json: current_story_user.user_sets.order_by(updated_at: 'desc'),
              each_serializer: StorySerializer,

--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -6,13 +6,13 @@ module SupplejackApi
     include Concerns::IgnoreMetrics
 
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+    before_action :prevent_anonymous!
 
     before_action :authenticate_admin!, :story_user_id_check, only: [:admin_index]
     before_action :story_user_check, except: %i[admin_index show]
     before_action :find_story, only: %i[show update destroy reposition_items]
     after_action :create_story_record_views, only: :show
 
-    before_action :prevent_anonymous!, except: [:index]
 
     def index
       render json: current_story_user.user_sets.order_by(updated_at: 'desc'),

--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -12,7 +12,7 @@ module SupplejackApi
     before_action :find_story, only: %i[show update destroy reposition_items]
     after_action :create_story_record_views, only: :show
 
-    before_action :prevent_anonymous!, only: [:create, :reposition_items]
+    before_action :prevent_anonymous!, except: [:index]
 
     def index
       render json: current_story_user.user_sets.order_by(updated_at: 'desc'),

--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -12,6 +12,8 @@ module SupplejackApi
     before_action :find_story, only: %i[show update destroy reposition_items]
     after_action :create_story_record_views, only: :show
 
+    before_action :prevent_anonymous!, only: [:create, :reposition_items]
+
     def index
       render json: current_story_user.user_sets.order_by(updated_at: 'desc'),
              each_serializer: StorySerializer,

--- a/app/controllers/supplejack_api/story_items_controller.rb
+++ b/app/controllers/supplejack_api/story_items_controller.rb
@@ -5,7 +5,7 @@ module SupplejackApi
     include Concerns::StoryItemsControllerMetrics
 
     before_action :prevent_anonymous!
-    
+
     before_action :find_story
     before_action :find_story_item, only: %i[show update destroy]
     before_action :story_user_check, except: %i[create update destroy]

--- a/app/controllers/supplejack_api/story_items_controller.rb
+++ b/app/controllers/supplejack_api/story_items_controller.rb
@@ -4,6 +4,8 @@ module SupplejackApi
   class StoryItemsController < SupplejackApplicationController
     include Concerns::StoryItemsControllerMetrics
 
+    before_action :prevent_anonymous!
+    
     before_action :find_story
     before_action :find_story_item, only: %i[show update destroy]
     before_action :story_user_check, except: %i[create update destroy]

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -78,11 +78,10 @@ module SupplejackApi
     end
 
     def prevent_anonymous!
-      if RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
-        render json: {
-          errors: I18n.t('errors.prevent_anonymous')
-        }, status: :forbidden
-      end
+      return unless RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
+      render json: {
+        errors: I18n.t('errors.prevent_anonymous')
+      }, status: :forbidden
     end
 
     def story_user_check

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -46,7 +46,6 @@ module SupplejackApi
 
     def current_auth_token
       if request.headers['Authentication-Token'] || params[:api_key]
-        Rails.logger.info "Authentication-Token : #{request.headers}"
         return request.headers['Authentication-Token'] || params[:api_key]
       end
 

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -49,9 +49,14 @@ module SupplejackApi
         Rails.logger.info "Authentication-Token : #{request.headers}"
         return @current_auth_token = request.headers['Authentication-Token'] || params[:api_key]
       end
+      @current_auth_token = begin
+                              SupplejackApi::User.find_by(name: 'anonymous').authentication_token
+                            rescue Mongoid::Errors::DocumentNotFound => e
+                              SupplejackApi::User.create!(name: 'anonymous').authentication_token
+                            end
 
-      Rails.logger.info "Assigning anonymous user"
-      @current_auth_token = SupplejackApi::User.find_by(name: 'anonymous').authentication_token
+      Rails.logger.info "Assigning anonymous user #{@current_auth_token}"
+      @current_auth_token
     end
 
     def current_user

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -45,7 +45,7 @@ module SupplejackApi
     end
 
     def current_auth_token
-      if request.headers['Authentication-Token'] || params[:api_key] 
+      if request.headers['Authentication-Token'] || params[:api_key]
         Rails.logger.info "Authentication-Token : #{request.headers}"
         return request.headers['Authentication-Token'] || params[:api_key]
       end

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -47,13 +47,10 @@ module SupplejackApi
     def current_auth_token
       if request.headers['Authentication-Token'] || params[:api_key] 
         Rails.logger.info "Authentication-Token : #{request.headers}"
-        return @current_auth_token = request.headers['Authentication-Token'] || params[:api_key]
+        return request.headers['Authentication-Token'] || params[:api_key]
       end
 
-      @current_auth_token = SupplejackApi::User.find_or_create_by(name: 'anonymous').authentication_token
-
-      Rails.logger.info "Assigning anonymous user #{@current_auth_token}"
-      @current_auth_token
+      SupplejackApi::User.find_or_create_by(name: 'anonymous').authentication_token
     end
 
     def current_user

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -79,7 +79,6 @@ module SupplejackApi
     end
 
     def prevent_anonymous!
-
       if RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
         render json: {
           errors: I18n.t('errors.prevent_anonymous')

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -50,7 +50,7 @@ module SupplejackApi
         return request.headers['Authentication-Token'] || params[:api_key]
       end
 
-      SupplejackApi::User.find_or_create_by(name: 'anonymous').authentication_token
+      SupplejackApi::User.find_or_create_by(name: 'anonymous', role: 'anonymous').authentication_token
     end
 
     def current_user

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -25,7 +25,9 @@ module SupplejackApi
     def authenticate_user!
       error_message = nil
 
-      if current_user
+      if current_auth_token.blank? && Rails.env.production?
+        error_message = I18n.t('users.blank_token')
+      elsif current_user
         if current_user.over_limit?
           error_message = I18n.t('users.reached_limit')
         else
@@ -45,6 +47,8 @@ module SupplejackApi
     end
 
     def current_auth_token
+      return request.headers['Authentication-Token'] || params[:api_key] if Rails.env.production?
+
       if request.headers['Authentication-Token'] || params[:api_key]
         return request.headers['Authentication-Token'] || params[:api_key]
       end

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -79,6 +79,7 @@ module SupplejackApi
 
     def prevent_anonymous!
       return unless RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
+
       render json: {
         errors: I18n.t('errors.prevent_anonymous')
       }, status: :forbidden

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -78,6 +78,15 @@ module SupplejackApi
       }, status: :forbidden
     end
 
+    def prevent_anonymous!
+
+      if RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
+        render json: {
+          errors: I18n.t('errors.prevent_anonymous')
+        }, status: :forbidden
+      end
+    end
+
     def story_user_check
       if params[:user_key]
         render_error_with(I18n.t('errors.user_not_found', key: params[:user_key]), :not_found) unless current_story_user

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -25,9 +25,7 @@ module SupplejackApi
     def authenticate_user!
       error_message = nil
 
-      if current_auth_token.blank?
-        error_message = I18n.t('users.blank_token')
-      elsif current_user
+      if current_user
         if current_user.over_limit?
           error_message = I18n.t('users.reached_limit')
         else
@@ -47,8 +45,13 @@ module SupplejackApi
     end
 
     def current_auth_token
-      Rails.logger.info "Authentication-Token : #{request.headers}"
-      @current_auth_token = request.headers['Authentication-Token'] || params[:api_key]
+      if request.headers['Authentication-Token'] || params[:api_key] 
+        Rails.logger.info "Authentication-Token : #{request.headers}"
+        return @current_auth_token = request.headers['Authentication-Token'] || params[:api_key]
+      end
+
+      Rails.logger.info "Assigning anonymous user"
+      @current_auth_token = SupplejackApi::User.find_by(name: 'anonymous').authentication_token
     end
 
     def current_user

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -49,11 +49,8 @@ module SupplejackApi
         Rails.logger.info "Authentication-Token : #{request.headers}"
         return @current_auth_token = request.headers['Authentication-Token'] || params[:api_key]
       end
-      @current_auth_token = begin
-                              SupplejackApi::User.find_by(name: 'anonymous').authentication_token
-                            rescue Mongoid::Errors::DocumentNotFound => e
-                              SupplejackApi::User.create!(name: 'anonymous').authentication_token
-                            end
+
+      @current_auth_token = SupplejackApi::User.find_or_create_by(name: 'anonymous').authentication_token
 
       Rails.logger.info "Assigning anonymous user #{@current_auth_token}"
       @current_auth_token

--- a/app/controllers/supplejack_api/user_sets_controller.rb
+++ b/app/controllers/supplejack_api/user_sets_controller.rb
@@ -6,6 +6,8 @@ module SupplejackApi
 
     respond_to :json
 
+    before_action :prevent_anonymous!
+
     prepend_before_action :find_user_set, only: %i[update destroy]
     before_action :authenticate_admin!, only: %i[admin_index public_index]
 

--- a/app/controllers/supplejack_api/user_sets_controller.rb
+++ b/app/controllers/supplejack_api/user_sets_controller.rb
@@ -8,7 +8,7 @@ module SupplejackApi
 
     before_action :prevent_anonymous!
 
-    prepend_before_action :find_user_set, only: %i[update destroy]
+    before_action :find_user_set, only: %i[update destroy]
     before_action :authenticate_admin!, only: %i[admin_index public_index]
 
     def index

--- a/app/models/supplejack_api/schema_definition.rb
+++ b/app/models/supplejack_api/schema_definition.rb
@@ -9,7 +9,7 @@ module SupplejackApi
       field: %i[type search_value search_boost multi_value search_as store
                 solr_name namespace namespace_field default_value date_format],
       group: %i[fields includes],
-      role: %i[default field_restrictions record_restrictions admin harvester],
+      role: %i[default field_restrictions record_restrictions admin harvester anonymous],
       namespace: [:url],
       mongo_index: %i[fields index_options],
       model_field: %i[type field_options validation index_fields index_options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ require 'sidekiq/web'
 Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
 
 SupplejackApi::Engine.routes.draw do
-  root to: 'records#index'
+  root to: 'records#index', defaults: {format: 'json'}
 
   namespace :stories do
     resources :moderations, only: [:index]
@@ -21,7 +21,7 @@ SupplejackApi::Engine.routes.draw do
     end
 
     # Records
-    resources :records, only: [:index, :show] do
+    resources :records, only: [:index, :show], defaults: {format: 'json'} do
       get :multiple, on: :collection
       get :more_like_this
     end

--- a/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories/moderations_controller_spec.rb
@@ -143,7 +143,7 @@ module SupplejackApi
       describe 'without an admin account' do
         it 'renders the appropriate message' do
           get :index, format: 'json'
-          expect(response.body).to eq '{"errors":"Please provide a API Key"}'
+          expect(response.body).to eq '{"errors":"You need Administrator privileges to perform this request"}'
         end
       end
     end

--- a/spec/controllers/supplejack_api/stories_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories_controller_spec.rb
@@ -32,6 +32,20 @@ module SupplejackApi
           end
         end
       end
+
+      context 'anonymous user' do
+        before do
+          get :index, params: { api_key: anonymous_user.api_key, user_key: anonymous_user.api_key, slim: 'false' }
+        end
+
+        it 'returns a 403 http code' do
+          expect(response.status).to eq 403
+        end
+
+        it 'returns an appropriate message' do
+          expect(JSON.parse(response.body)['errors']).to include(I18n.t('errors.prevent_anonymous'))
+        end
+      end
     end
 
     describe 'GET admin_index' do
@@ -129,6 +143,20 @@ module SupplejackApi
             .to eq(story.set_items.map { |x| x[:content][:display_collection] })
 
           expect(SupplejackApi::RequestMetric.first.metric).to eq 'user_story_views'
+        end
+      end
+
+      context 'anonymous user' do
+        before do
+          get :show, params: { api_key: anonymous_user.api_key, id: 1 }
+        end
+
+        it 'returns a 403 http code' do
+          expect(response.status).to eq 403
+        end
+
+        it 'returns an appropriate message' do
+          expect(JSON.parse(response.body)['errors']).to include(I18n.t('errors.prevent_anonymous'))
         end
       end
     end

--- a/spec/controllers/supplejack_api/stories_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories_controller_spec.rb
@@ -5,7 +5,7 @@ module SupplejackApi
     routes { SupplejackApi::Engine.routes }
 
     let(:user) { create(:user) }
-    let(:anonymous_user) { create(:user, role: 'anonymous') } 
+    let(:anonymous_user) { create(:user, role: 'anonymous') }
     let(:api_key) { user.api_key }
 
     describe 'GET index' do
@@ -201,7 +201,11 @@ module SupplejackApi
       context 'anonymous user' do
         let(:story_name) { 'StoryNameGoesHere' }
 
-        before { post :create, params: { user_key: anonymous_user.api_key, api_key: anonymous_user.api_key, story: { name: story_name } } }
+        before do
+          post :create,
+               params: { user_key: anonymous_user.api_key, api_key: anonymous_user.api_key,
+                         story: { name: story_name } }
+        end
 
         it 'returns a 403 http code' do
           expect(response.status).to eq 403
@@ -312,10 +316,11 @@ module SupplejackApi
             { id: items[0].id, position: 2 },
             { id: items[1].id, position: 1 },
             { id: items[2].id, position: 3 }
-        ]
+          ]
 
           post :reposition_items,
-               params: { story_id: story.id.to_s, api_key: anonymous_user.api_key, user_key: anonymous_user.api_key, items: reposition_params }
+               params: { story_id: story.id.to_s, api_key: anonymous_user.api_key, user_key: anonymous_user.api_key,
+                         items: reposition_params }
         end
 
         it 'returns a 403 http code' do

--- a/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
+++ b/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
@@ -64,6 +64,8 @@ module SupplejackApi
     end
 
     describe '#authenticate_user!' do
+      let!(:user) { create(:user, name: 'anonymous') }
+
       context 'when api_key & Authentication-Token is nil' do
         before do
           allow(controller).to receive(:params) { { api_key: nil } }
@@ -76,12 +78,9 @@ module SupplejackApi
           }
         end
 
-        it 'renders blank_token error' do
-          expect(controller).to receive(:render).with(
-            { json: { errors: I18n.t('users.blank_token') }, status: :forbidden }
-          )
-
+        it 'assigns the anonymous user as the current_user' do
           controller.authenticate_user!
+          expect(assigns(:current_user).name).to eq 'anonymous'
         end
       end
 

--- a/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
+++ b/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
@@ -77,7 +77,7 @@ module SupplejackApi
         end
 
         it 'assigns the anonymous user as the current_user' do
-          create(:user, name: 'anonymous') 
+          create(:user, name: 'anonymous')
           controller.authenticate_user!
           expect(assigns(:current_user).name).to eq 'anonymous'
         end

--- a/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
+++ b/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
@@ -64,8 +64,6 @@ module SupplejackApi
     end
 
     describe '#authenticate_user!' do
-      let!(:user) { create(:user, name: 'anonymous') }
-
       context 'when api_key & Authentication-Token is nil' do
         before do
           allow(controller).to receive(:params) { { api_key: nil } }
@@ -79,7 +77,15 @@ module SupplejackApi
         end
 
         it 'assigns the anonymous user as the current_user' do
+          create(:user, name: 'anonymous') 
           controller.authenticate_user!
+          expect(assigns(:current_user).name).to eq 'anonymous'
+        end
+
+        it 'creates the anonymous user when it does not exist' do
+          expect(SupplejackApi::User.count).to eq 0
+          controller.authenticate_user!
+          expect(SupplejackApi::User.count).to eq 1
           expect(assigns(:current_user).name).to eq 'anonymous'
         end
       end

--- a/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
+++ b/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
@@ -77,9 +77,10 @@ module SupplejackApi
         end
 
         it 'assigns the anonymous user as the current_user' do
-          create(:user, name: 'anonymous')
+          create(:user, name: 'anonymous', role: 'anonymous')
           controller.authenticate_user!
           expect(assigns(:current_user).name).to eq 'anonymous'
+          expect(assigns(:current_user).role).to eq 'anonymous'
         end
 
         it 'creates the anonymous user when it does not exist' do
@@ -87,6 +88,7 @@ module SupplejackApi
           controller.authenticate_user!
           expect(SupplejackApi::User.count).to eq 1
           expect(assigns(:current_user).name).to eq 'anonymous'
+          expect(assigns(:current_user).role).to eq 'anonymous'
         end
       end
 

--- a/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
+++ b/spec/controllers/supplejack_api/supplejack_application_controller_spec.rb
@@ -266,5 +266,30 @@ module SupplejackApi
         end
       end
     end
+
+    describe '#prevent_anonymous' do
+      context 'when user is anonymous' do
+        before do
+          allow(controller).to receive(:request) {
+            double(:request,
+                   ip: '1.1.1.1',
+                   format: :json,
+                   params: { controller: 'supplejack_api/stories', action: 'show' },
+                   headers: { 'Authentication-Token' => create(:user, role: 'anonymous').authentication_token })
+          }
+        end
+
+        it 'renders prevent_anonymous error' do
+          expect(controller).to receive(:render).with(
+            {
+              json: { errors: I18n.t('errors.prevent_anonymous') },
+              status: :forbidden
+            }
+          )
+
+          controller.prevent_anonymous!
+        end
+      end
+    end
   end
 end

--- a/spec/dummy/app/supplejack_api/record_schema.rb
+++ b/spec/dummy/app/supplejack_api/record_schema.rb
@@ -82,6 +82,7 @@ class RecordSchema
   end
 
    # Roles
+  role :anonymous, anonymous: true
   role :developer, default: true
   role :admin, admin: true
   role :harvester, harvester: true

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
     user_key_missing: 'Mandatory parameter user_key missing'
     user_set_not_found: "UserSet with id: %{id} was not found."
     user_not_authorized_for_story: "Provided user key is not authorized to access this story"
+    prevent_anonymous: "Anonymous request is not allowed"
 
   time:
     formats:

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe 'Stories Endpoints', type: :request do
       it 'returns an error' do
         response_attributes = JSON.parse(response.body)
 
-        expect(response_attributes).to eq({ 'errors' => 'You need Administrator privileges to perform this request' })
+        expect(response_attributes).to eq({ 'errors' => I18n.t('errors.prevent_anonymous') })
       end
     end
 

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe 'Stories Endpoints', type: :request do
       it 'returns an error' do
         response_attributes = JSON.parse(response.body)
 
-        expect(response_attributes).to eq({ 'errors' => 'Please provide a API Key' })
+        expect(response_attributes).to eq({ 'errors' => 'You need Administrator privileges to perform this request' })
       end
     end
 


### PR DESCRIPTION
**Acceptance Criteria**
- Read-only requests for public data only can be made without an API key (ie. anonymously)
- Suitable limits (eg. request rate limit, response rate limit?!, maximum request volume, etc.) are put in place to prevent anonymous requests overwhelming resources (ie. costing too much or degrading performance for priority applications).


**Notes**
- Seems like we should be able to do something relatively simple in the WAF/CF to rate limit anonymous requests, which seems ideal.
- Don't overcook it. :-)
- So can a user bypass rate limit if they add an API key? id rate limiting is implemented in the WAF
- Discuss proposed limiting approaches with PO before implementing. 