### PR TITLE
INVESTIMENT RESOLVE NIL RECORDMETRIC ISSUE: As Dan, I want RecordMetrics to get all the data it needs, so that it can be processed correctly

### DIFF
--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -108,7 +108,7 @@ module SupplejackApi
         { record_id: record[:record_id], display_collection: record[:content][:display_collection] }
       end
       # remove invalid story items for the metrics, eg: user inputed text
-      records.select! { |record| record[:record_id].present? && record[:display_collection].present? }
+      records.reject! { |record| record[:record_id].nil? || record[:display_collection].nil? }
 
       SupplejackApi::RequestMetric.spawn(records, 'user_story_views') if records.any?
     end

--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -102,11 +102,14 @@ module SupplejackApi
       return unless log_request_for_metrics?
 
       payload = JSON.parse(response.body)
-      log = payload['contents']&.map do |record|
+      return if payload['contents'].blank?
+
+      # contains a bug: some story items have an empty record_id because they're just user inputs as text
+      records = payload['contents'].map do |record|
         { record_id: record['record_id'], display_collection: record['content']['display_collection'] }
       end
 
-      SupplejackApi::RequestMetric.spawn(log, 'user_story_views') if log
+      SupplejackApi::RequestMetric.spawn(records, 'user_story_views') if records
     end
   end
 end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -46,11 +46,13 @@ module SupplejackApi
 
     def self.spawn(record_id, metrics, display_collection, date = Time.now.utc.beginning_of_day.yesterday)
       return unless SupplejackApi.config.log_metrics == true
+      return if record_id.nil? || display_collection.nil?
 
-      record = where(record_id: record_id, date: date).first
-      record = new(record_id: record_id, date: date, display_collection: display_collection) if record.nil?
-      record.inc(metrics)
-      record.save
+      collection.update_one(
+        { record_id: record_id, date: date.to_date, display_collection: display_collection },
+        { '$inc' => metrics },
+        upsert: true
+      )
     end
   end
 end

--- a/app/models/supplejack_api/record_metric.rb
+++ b/app/models/supplejack_api/record_metric.rb
@@ -47,11 +47,10 @@ module SupplejackApi
     def self.spawn(record_id, metrics, display_collection, date = Time.now.utc.beginning_of_day.yesterday)
       return unless SupplejackApi.config.log_metrics == true
 
-      collection.update_one(
-        { record_id: record_id, date: date.to_date, display_collection: display_collection },
-        { '$inc' => metrics },
-        upsert: true
-      )
+      record = where(record_id: record_id, date: date).first
+      record = new(record_id: record_id, date: date, display_collection: display_collection) if record.nil?
+      record.inc(metrics)
+      record.save
     end
   end
 end

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -16,6 +16,7 @@ module SupplejackApi
     def records_integrity
       return unless records.any? { |record| record[:record_id].nil? || record[:display_collection].nil? }
 
+      Rails.logger.info('RequestMetric failed the records_integrity check')
       errors.add(:records, 'must contain each a record_id and a display_collection')
     end
 

--- a/app/models/supplejack_api/request_metric.rb
+++ b/app/models/supplejack_api/request_metric.rb
@@ -10,7 +10,14 @@ module SupplejackApi
     field :metric,  type: String
 
     validates :records, presence: true
+    validate :records_integrity
     validates :metric,  presence: true
+
+    def records_integrity
+      return unless records.any? { |record| record[:record_id].nil? || record[:display_collection].nil? }
+
+      errors.add(:records, 'must contain each a record_id and a display_collection')
+    end
 
     def self.spawn(records, metric, date = Time.now.utc.beginning_of_day)
       return unless SupplejackApi.config.log_metrics == true

--- a/spec/controllers/supplejack_api/stories_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories_controller_spec.rb
@@ -116,7 +116,7 @@ module SupplejackApi
       end
 
       context 'when successful' do
-        let(:response_body) { JSON.parse(response.body).deep_symbolize_keys }
+        let(:response_body) { JSON.parse(response.body, symbolize_names: true) }
         let(:story)         { user.user_sets.first }
         let(:story_id)      { story.id.to_s }
 

--- a/spec/controllers/supplejack_api/stories_controller_spec.rb
+++ b/spec/controllers/supplejack_api/stories_controller_spec.rb
@@ -109,6 +109,10 @@ module SupplejackApi
         it 'includes the error message' do
           expect(response.body).to include(I18n.t('errors.story_not_found', id: '1231231231'))
         end
+
+        it 'does not create a user_story_views entry for RequestMetric' do
+          expect(SupplejackApi::RequestMetric.count).to eq 0
+        end
       end
 
       context 'when successful' do

--- a/spec/models/supplejack_api/record_metric_spec.rb
+++ b/spec/models/supplejack_api/record_metric_spec.rb
@@ -75,12 +75,14 @@ RSpec.describe SupplejackApi::RecordMetric do
 
   describe '::spawn' do
     let!(:record_metric) do
-      create(:record_metric, {
-        record_id: 1,
-        page_views: 1,
-        display_collection: 'NDHA',
-        date: Time.now.utc.yesterday
-      })
+      create(
+        :record_metric, {
+          record_id: 1,
+          page_views: 1,
+          display_collection: 'NDHA',
+          date: Time.now.utc.yesterday
+        }
+      )
     end
 
     it 'creates a new RecordMetric when there is not one for the provided day and record_id' do

--- a/spec/models/supplejack_api/request_metric_spec.rb
+++ b/spec/models/supplejack_api/request_metric_spec.rb
@@ -25,6 +25,36 @@ RSpec.describe SupplejackApi::RequestMetric do
     end
   end
 
+  describe 'validations' do
+    it 'must have an array in records' do
+      rm = create(:request_metric)
+      rm.records = []
+      rm.save
+      expect(rm.errors.full_messages).to eq ["Records Records field can't be blank."]
+    end
+
+    it 'must have a metric set' do
+      rm = create(:request_metric)
+      rm.metric = nil
+      rm.save
+      expect(rm.errors.full_messages).to eq ["Metric Metric field can't be blank."]
+    end
+
+    it 'must not have a record with a nil record_id' do
+      rm = create(:request_metric)
+      rm.records = [{ record_id: nil, display_collection: 'test' }]
+      rm.save
+      expect(rm.errors.full_messages).to eq ['Records must contain each a record_id and a display_collection']
+    end
+
+    it 'must not have a record with a nil display_collection' do
+      rm = create(:request_metric)
+      rm.records = [{ record_id: 1, display_collection: nil }]
+      rm.save
+      expect(rm.errors.full_messages).to eq ['Records must contain each a record_id and a display_collection']
+    end
+  end
+
   describe '#summarize' do
     let!(:appeared_in_searches_yesterday) { create_list(:request_metric, 5, date: 1.day.ago.utc.to_date) }
     let!(:user_set_views_yesterday) do


### PR DESCRIPTION
[INVESTIMENT RESOLVE NIL RECORDMETRIC ISSUE: As Dan, I want RecordMetrics to get all the data it needs, so that it can be processed correctly](https://www.pivotaltracker.com/story/show/180106608)

STORY
=====

**Acceptance Criteria**
- Investigate and/or fix the issue that causes `nil` in record_id/display_collections in RecordMetric
- Delete all the existing problematic (nil) RecordMetrics



**Notes**
- Depending on the fix, it could be worth adding some validation to prevent it happening again
- Related stories https://www.pivotaltracker.com/story/show/179879674 and  https://www.pivotaltracker.com/story/show/179845966
- We are entering nil record_id & display_collection from DNZ api to RecordMetric, this entry skips the validation. These entries are not processed during metrics creation and not deleted.
- Reasons for deleting
 - There are only 2000ish that refer to "active" records
 - Majority of those seem to be TVNZ (which is a bit junky anyway)
