### PR TITLE
CONFIGURE META TO RESPONSES GLOBALLY

### DIFF
--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -22,9 +22,9 @@ module SupplejackApi
       if @search.valid?
         respond_to do |format|
           format.json do
-            render json: @search, serializer: self.class.search_serializer_class, record_fields: available_fields,
-                   record_includes: available_fields, root: 'search', adapter: :json,
-                   callback: params['jsonp']
+            render_json_with json: @search, serializer: self.class.search_serializer_class,
+                             record_fields: available_fields, record_includes: available_fields,
+                             root: 'search', adapter: :json, callback: params['jsonp']
           end
           format.xml do
             options = { serializer: self.class.search_serializer_class, record_includes: available_fields,
@@ -50,9 +50,9 @@ module SupplejackApi
 
       respond_to do |format|
         format.json do
-          render json: @record, serializer: self.class.record_serializer_class,
-                 fields: available_fields, root: 'record',
-                 include: available_fields, adapter: :json, callback: params['jsonp']
+          render_json_with json: @record, serializer: self.class.record_serializer_class,
+                           fields: available_fields, root: 'record',
+                           include: available_fields, adapter: :json, callback: params['jsonp']
         end
         format.xml do
           options = { serializer: self.class.record_serializer_class,

--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module SupplejackApi
-  # rubocop:disable Metrics/ClassLength
   class RecordsController < SupplejackApplicationController
     include SupplejackApi::Concerns::RecordsControllerMetrics
     include ActionController::RequestForgeryProtection
@@ -29,10 +28,8 @@ module SupplejackApi
           format.xml do
             options = { serializer: self.class.search_serializer_class, record_includes: available_fields,
                         record_fields: available_fields, request_format: 'xml', root: 'search' }
-            serializable_resource = ActiveModelSerializers::SerializableResource.new(@search, options)
-            # The double as_json is required to render the inner json object as json as well as the exterior object
 
-            render xml: serializable_resource.as_json.as_json.to_xml(root: 'search')
+            render_xml_with(@search, options, 'search')
           end
           format.rss { respond_with @search }
         end
@@ -55,10 +52,10 @@ module SupplejackApi
                            include: available_fields, adapter: :json, callback: params['jsonp']
         end
         format.xml do
-          options = { serializer: self.class.record_serializer_class,
-                      fields: available_fields, include: available_fields, root: 'record' }
-          serializable_resource = ActiveModelSerializers::SerializableResource.new(@record, options)
-          render xml: serializable_resource.as_json.to_xml(root: 'record')
+          options = { serializer: self.class.record_serializer_class, root: 'record',
+                      fields: available_fields, include: available_fields }
+
+          render_xml_with(@record, options, 'record')
         end
         format.rss { respond_with @record }
       end
@@ -141,5 +138,4 @@ module SupplejackApi
       _render_to_body_with_renderer(options) || super
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/controllers/supplejack_api/stories_controller.rb
+++ b/app/controllers/supplejack_api/stories_controller.rb
@@ -14,10 +14,9 @@ module SupplejackApi
     after_action :create_story_record_views, only: :show
 
     def index
-      render json: current_story_user.user_sets.order_by(updated_at: 'desc'),
-             each_serializer: StorySerializer,
-             scope: { slim: params[:slim] != 'false' },
-             root: false
+      render_json_with json: current_story_user.user_sets.order_by(updated_at: 'desc'),
+                       each_serializer: StorySerializer, root: false,
+                       scope: { slim: params[:slim] != 'false' }
     end
 
     # This route is created for front end application to get all stories for a user.
@@ -26,15 +25,15 @@ module SupplejackApi
     def admin_index
       authorize(UserSet)
 
-      render json: @story_user.user_sets.order_by(updated_at: 'desc'),
-             each_serializer: StorySerializer,
-             root: false, scope: { slim: true }
+      render_json_with json: @story_user.user_sets.order_by(updated_at: 'desc'),
+                       each_serializer: StorySerializer,
+                       root: false, scope: { slim: true }
     end
 
     def show
       authorize(@story)
 
-      render json: StorySerializer.new(@story, scope: { slim: false }).to_json(include_root: false), status: :ok
+      render_json_with json: @story, serializer: StorySerializer
     end
 
     def create
@@ -42,7 +41,8 @@ module SupplejackApi
 
       if story.valid?
         story.save!
-        render json: StorySerializer.new(story, scope: { slim: false }).to_json(include_root: false), status: :created
+        render_json_with json: story, serializer: StorySerializer,
+                         scope: { slim: false }, status: :created
       else
         render_error_with(story.errors.messages, :bad_request)
       end
@@ -52,7 +52,8 @@ module SupplejackApi
       authorize(@story)
 
       if @story.update(story_params)
-        render json: StorySerializer.new(@story, scope: { slim: false }).to_json(include_root: false), status: :ok
+        render_json_with json: @story, serializer: StorySerializer,
+                         scope: { slim: false }
       else
         render_error_with(@story.errors.messages, :bad_request)
       end

--- a/app/controllers/supplejack_api/story_items_controller.rb
+++ b/app/controllers/supplejack_api/story_items_controller.rb
@@ -12,12 +12,11 @@ module SupplejackApi
 
     def index
       render json: @story.set_items,
-             each_serializer: StoryItemSerializer,
-             root: false
+             each_serializer: StoryItemSerializer
     end
 
     def show
-      render json: StoryItemSerializer.new(@item).to_json(include_root: false), status: :ok
+      render_json_with json: @item, serializer: StoryItemSerializer
     end
 
     def create
@@ -27,7 +26,7 @@ module SupplejackApi
         @story.cover_thumbnail = item.content[:image_url] unless @story.cover_thumbnail
         @story.save!
 
-        render json: StoryItemSerializer.new(item).to_json(include_root: false), status: :ok
+        render_json_with json: item, serializer: StoryItemSerializer
       else
         render_error_with(item.errors.messages.values.join(', '), :bad_request)
       end
@@ -41,7 +40,7 @@ module SupplejackApi
           @story.update_attribute(:cover_thumbnail, nil)
         end
 
-        render json: StoryItemSerializer.new(@item).to_json(include_root: false), status: :ok
+        render_json_with json: @item, serializer: StoryItemSerializer
       else
         render_error_with('Failed to update', :bad_request)
       end

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -99,5 +99,11 @@ module SupplejackApi
     def user_requires_admin_privileges
       render_error_with(I18n.t('errors.requires_admin_privileges'), :unauthorized)
     end
+
+    def render_json_with(attributes)
+      attributes.merge!(meta: SupplejackApi.config.meta_response_field) if SupplejackApi.config.meta_response_field
+
+      render attributes
+    end
   end
 end

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -105,5 +105,16 @@ module SupplejackApi
 
       render attributes
     end
+
+    def render_xml_with(resource, options, root)
+      serializable_resource = ActiveModelSerializers::SerializableResource.new(resource, options).as_json
+
+      if SupplejackApi.config.meta_response_field
+        serializable_resource.merge!(meta: SupplejackApi.config.meta_response_field)
+      end
+
+      # The double as_json is required to render the inner json object as json as well as the exterior object
+      render xml: serializable_resource.as_json.to_xml(root: root)
+    end
   end
 end

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -101,7 +101,10 @@ module SupplejackApi
     end
 
     def render_json_with(attributes)
-      attributes.merge!(meta: SupplejackApi.config.meta_response_field) if SupplejackApi.config.meta_response_field
+      if SupplejackApi.config.global_response_field
+        field = SupplejackApi.config.global_response_field
+        attributes.merge!(meta: field[:value], meta_key: field[:key_name])
+      end
 
       render attributes
     end
@@ -109,12 +112,15 @@ module SupplejackApi
     def render_xml_with(resource, options, root)
       serializable_resource = ActiveModelSerializers::SerializableResource.new(resource, options).as_json
 
-      if SupplejackApi.config.meta_response_field
-        serializable_resource.merge!(meta: SupplejackApi.config.meta_response_field)
+      serializable_resource = { root => serializable_resource } if root
+
+      if SupplejackApi.config.global_response_field
+        field = SupplejackApi.config.global_response_field
+        serializable_resource.merge!(field[:key_name] => field[:value])
       end
 
       # The double as_json is required to render the inner json object as json as well as the exterior object
-      render xml: serializable_resource.as_json.to_xml(root: root)
+      render xml: serializable_resource.as_json.to_xml
     end
   end
 end

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -112,15 +112,13 @@ module SupplejackApi
     def render_xml_with(resource, options, root)
       serializable_resource = ActiveModelSerializers::SerializableResource.new(resource, options).as_json
 
-      serializable_resource = { root => serializable_resource } if root
-
       if SupplejackApi.config.global_response_field
         field = SupplejackApi.config.global_response_field
         serializable_resource.merge!(field[:key_name] => field[:value])
       end
 
       # The double as_json is required to render the inner json object as json as well as the exterior object
-      render xml: serializable_resource.as_json.to_xml
+      render xml: serializable_resource.as_json.to_xml(root: root)
     end
   end
 end

--- a/app/controllers/supplejack_api/users_controller.rb
+++ b/app/controllers/supplejack_api/users_controller.rb
@@ -5,14 +5,14 @@ module SupplejackApi
     include Pundit
 
     before_action :find_and_authorize_user, only: %i[show update destroy]
-    respond_to :xml, :json
     rescue_from Pundit::NotAuthorizedError, with: :user_requires_admin_privileges
+    respond_to :json
+    before_action :authenticate_admin!
 
     def show
-      respond_to do |format|
-        format.json { render json: @user, root: 'user', adapter: :json }
-        format.xml  { render_xml_with(@user, { serializer: UserSerializer }, 'user') }
-      end
+      @user = User.custom_find(params[:id])
+
+      render json: @user, root: 'user', adapter: :json
     end
 
     def create

--- a/app/controllers/supplejack_api/users_controller.rb
+++ b/app/controllers/supplejack_api/users_controller.rb
@@ -11,12 +11,7 @@ module SupplejackApi
     def show
       respond_to do |format|
         format.json { render json: @user, root: 'user', adapter: :json }
-        format.xml  do
-          options = { serializer: UserSerializer }
-          serializable_resource = ActiveModelSerializers::SerializableResource.new(@user, options)
-
-          render xml: serializable_resource.as_json.to_xml(root: 'user')
-        end
+        format.xml  { render_xml_with(@user, { serializer: UserSerializer }, 'user') }
       end
     end
 

--- a/app/controllers/supplejack_api/users_controller.rb
+++ b/app/controllers/supplejack_api/users_controller.rb
@@ -7,7 +7,6 @@ module SupplejackApi
     before_action :find_and_authorize_user, only: %i[show update destroy]
     rescue_from Pundit::NotAuthorizedError, with: :user_requires_admin_privileges
     respond_to :json
-    before_action :authenticate_admin!
 
     def show
       render json: @user, root: 'user', adapter: :json

--- a/app/controllers/supplejack_api/users_controller.rb
+++ b/app/controllers/supplejack_api/users_controller.rb
@@ -10,8 +10,6 @@ module SupplejackApi
     before_action :authenticate_admin!
 
     def show
-      @user = User.custom_find(params[:id])
-
       render json: @user, root: 'user', adapter: :json
     end
 

--- a/spec/dummy/config/initializers/supplejack_api.rb
+++ b/spec/dummy/config/initializers/supplejack_api.rb
@@ -1,4 +1,5 @@
 SupplejackApi.setup do |config|
   config.log_metrics = true
   config.record_batch_size_for_mongo_queries_and_solr_indexing = 500
+  config.meta_response_field = nil
 end

--- a/spec/dummy/config/initializers/supplejack_api.rb
+++ b/spec/dummy/config/initializers/supplejack_api.rb
@@ -1,5 +1,5 @@
 SupplejackApi.setup do |config|
   config.log_metrics = true
   config.record_batch_size_for_mongo_queries_and_solr_indexing = 500
-  config.meta_response_field = nil
+  config.global_response_field = nil
 end

--- a/spec/requests/meta_response_field_spec.rb
+++ b/spec/requests/meta_response_field_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Meta field test', type: :request do
   let(:record) { create(:record) }
 
   describe '#show' do
-    context 'when meta_response_field is not configured' do
+    context 'when global_response_field is not configured' do
       context 'when format is xml' do
         before { get "/v3/records/#{record.record_id}.xml?api_key=#{user.authentication_token}" }
 
@@ -37,15 +37,15 @@ RSpec.describe 'Meta field test', type: :request do
       end
     end
 
-    context 'when meta_response_field is configured' do
-      before { SupplejackApi.config.meta_response_field = { terms_of_use: 'terms_of_use' } }
-      after  { SupplejackApi.config.meta_response_field = nil }
+    context 'when global_response_field is configured' do
+      before { SupplejackApi.config.global_response_field = { key_name: 'terms_of_use', value: 'terms of use' } }
+      after  { SupplejackApi.config.global_response_field = nil }
 
       context 'when format is xml' do
         before { get "/v3/records/#{record.record_id}.xml?api_key=#{user.authentication_token}" }
 
         it 'returns record with meta' do
-          expect(response.body).to include('<terms-of-use>terms_of_use</terms-of-use>')
+          expect(response.body).to include('<terms-of-use>terms of use</terms-of-use>')
         end
       end
 
@@ -57,7 +57,7 @@ RSpec.describe 'Meta field test', type: :request do
 
           expect(response_attributes).to eq(
             {
-              'meta' => { 'terms_of_use' => 'terms_of_use' },
+              'terms_of_use' => 'terms of use',
               'record' => {
                 'address' => record.address,
                 'created_at' => record.created_at.strftime('%y/%d/%m'),

--- a/spec/requests/meta_response_field_spec.rb
+++ b/spec/requests/meta_response_field_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Meta field test', type: :request do
+  let(:user)   { create(:user) }
+  let(:record) { create(:record, name: Faker::Movie.title) }
+
+  describe '#show' do
+    context 'when meta_response_field is not configured' do
+      before { get "/v3/records/#{record.record_id}.json?api_key=#{user.authentication_token}" }
+
+      it 'returns record' do
+        response_attributes = JSON.parse(response.body)
+
+        expect(response_attributes).to eq(
+          {
+            'record' => {
+              'address' => record.address,
+              'created_at' => record.created_at.strftime('%y/%d/%m'),
+              'email' => record.email,
+              'name' => record.name,
+              'updated_at' => record.created_at.as_json
+            }
+          }
+        )
+      end
+    end
+
+    context 'when meta_response_field is configured' do
+      before do
+        SupplejackApi.config.meta_response_field = { terms_of_use: 'terms_of_use' }
+
+        get "/v3/records/#{record.record_id}.json?api_key=#{user.authentication_token}"
+      end
+
+      after { SupplejackApi.config.meta_response_field = nil }
+
+      it 'returns record with meta' do
+        response_attributes = JSON.parse(response.body)
+
+        expect(response_attributes).to eq(
+          {
+            'meta' => { 'terms_of_use' => 'terms_of_use' },
+            'record' => {
+              'address' => record.address,
+              'created_at' => record.created_at.strftime('%y/%d/%m'),
+              'email' => record.email,
+              'name' => record.name,
+              'updated_at' => record.created_at.as_json
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/meta_response_field_spec.rb
+++ b/spec/requests/meta_response_field_spec.rb
@@ -4,53 +4,70 @@ require 'spec_helper'
 
 RSpec.describe 'Meta field test', type: :request do
   let(:user)   { create(:user) }
-  let(:record) { create(:record, name: Faker::Movie.title) }
+  let(:record) { create(:record) }
 
   describe '#show' do
     context 'when meta_response_field is not configured' do
-      before { get "/v3/records/#{record.record_id}.json?api_key=#{user.authentication_token}" }
+      context 'when format is xml' do
+        before { get "/v3/records/#{record.record_id}.xml?api_key=#{user.authentication_token}" }
 
-      it 'returns record' do
-        response_attributes = JSON.parse(response.body)
+        it 'returns record without meta' do
+          expect(response.body).not_to include('<terms-of-use>terms_of_use</terms-of-use>')
+        end
+      end
 
-        expect(response_attributes).to eq(
-          {
-            'record' => {
-              'address' => record.address,
-              'created_at' => record.created_at.strftime('%y/%d/%m'),
-              'email' => record.email,
-              'name' => record.name,
-              'updated_at' => record.created_at.as_json
+      context 'when format is json' do
+        before { get "/v3/records/#{record.record_id}.json?api_key=#{user.authentication_token}" }
+
+        it 'returns record without meta' do
+          response_attributes = JSON.parse(response.body)
+
+          expect(response_attributes).to eq(
+            {
+              'record' => {
+                'address' => record.address,
+                'created_at' => record.created_at.strftime('%y/%d/%m'),
+                'email' => record.email,
+                'name' => record.name,
+                'updated_at' => record.created_at.as_json
+              }
             }
-          }
-        )
+          )
+        end
       end
     end
 
     context 'when meta_response_field is configured' do
-      before do
-        SupplejackApi.config.meta_response_field = { terms_of_use: 'terms_of_use' }
+      before { SupplejackApi.config.meta_response_field = { terms_of_use: 'terms_of_use' } }
+      after  { SupplejackApi.config.meta_response_field = nil }
 
-        get "/v3/records/#{record.record_id}.json?api_key=#{user.authentication_token}"
+      context 'when format is xml' do
+        before { get "/v3/records/#{record.record_id}.xml?api_key=#{user.authentication_token}" }
+
+        it 'returns record with meta' do
+          expect(response.body).to include('<terms-of-use>terms_of_use</terms-of-use>')
+        end
       end
 
-      after { SupplejackApi.config.meta_response_field = nil }
+      context 'when format is json' do
+        before { get "/v3/records/#{record.record_id}.json?api_key=#{user.authentication_token}" }
 
-      it 'returns record with meta' do
-        response_attributes = JSON.parse(response.body)
+        it 'returns record with meta' do
+          response_attributes = JSON.parse(response.body)
 
-        expect(response_attributes).to eq(
-          {
-            'meta' => { 'terms_of_use' => 'terms_of_use' },
-            'record' => {
-              'address' => record.address,
-              'created_at' => record.created_at.strftime('%y/%d/%m'),
-              'email' => record.email,
-              'name' => record.name,
-              'updated_at' => record.created_at.as_json
+          expect(response_attributes).to eq(
+            {
+              'meta' => { 'terms_of_use' => 'terms_of_use' },
+              'record' => {
+                'address' => record.address,
+                'created_at' => record.created_at.strftime('%y/%d/%m'),
+                'email' => record.email,
+                'name' => record.name,
+                'updated_at' => record.created_at.as_json
+              }
             }
-          }
-        )
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
**Acceptance Criteria**
- Add a api_terms_of_use as the first element in all API responses
- Element to contain "https://api.digitalnz.org/terms-of-use"

**Changes**
- This meta field is configurable at the consumer API so that meta fields will show up in records & stories endpoints.