### PR TITLE
FIX: METRICS PROCESSINF DATE

### DIFF
--- a/app/models/supplejack_api/collection_metric.rb
+++ b/app/models/supplejack_api/collection_metric.rb
@@ -31,7 +31,7 @@ module SupplejackApi
       )
     end
 
-    def self.spawn(date_range = (30.days.ago.utc..Time.now.yesterday.utc.beginning_of_day))
+    def self.spawn(date_range = (30.days.ago.utc..Time.zone.now.yesterday.beginning_of_day))
       return unless SupplejackApi.config.log_metrics == true
 
       dates = SupplejackApi::RecordMetric.where(date: date_range).map(&:date).uniq


### PR DESCRIPTION
Cron that run the job is

```
  # everyday at: 1:30am NZD - UTC time: 1:30pm
  schedule: "30 13 * * *"
```

`Time.now.yesterday.utc.beginning_of_day` was fetching 2 days ahead for NZST. Fixed by removing utc.
