### PR TITLE
ADJUST API SORT ON NATLIB FAV CALL

### DIFF
--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -63,6 +63,7 @@ module SupplejackApi
 
     def multiple
       @records = SupplejackApi::Record.find_multiple(params[:record_ids])
+
       respond_with @records, each_serializer: self.class.record_serializer_class, root: 'records', adapter: :json
     end
 

--- a/app/models/supplejack_api/concerns/record.rb
+++ b/app/models/supplejack_api/concerns/record.rb
@@ -42,12 +42,13 @@ module SupplejackApi::Concerns::Record
       return [] unless ids.try(:any?)
 
       string_ids = ids.find_all { |id| id.to_s.length > 10 }
-      integer_ids = ids.find_all { |id| id.to_s.length <= 10 }
+      integer_ids = ids.find_all { |id| id.to_s.length <= 10 }.map(&:to_i)
 
       records = []
       records += active.find(string_ids) if string_ids.present?
       records += active.where(:record_id.in => integer_ids)
-      records = records.sort_by { |r| ids.find_index(r.record_id) || 100 }
+
+      records.sort_by { |r| integer_ids.find_index(r.record_id) || 100 }
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/app/models/supplejack_api/concerns/record.rb
+++ b/app/models/supplejack_api/concerns/record.rb
@@ -42,13 +42,15 @@ module SupplejackApi::Concerns::Record
       return [] unless ids.try(:any?)
 
       string_ids = ids.find_all { |id| id.to_s.length > 10 }
-      integer_ids = ids.find_all { |id| id.to_s.length <= 10 }.map(&:to_i)
+      integer_ids = ids.find_all { |id| id.to_s.length <= 10 }
 
       records = []
       records += active.find(string_ids) if string_ids.present?
       records += active.where(:record_id.in => integer_ids)
 
-      records.sort_by { |r| integer_ids.find_index(r.record_id) || 100 }
+      records.sort_by do |record|
+        ids.find_index(record.record_id) || ids.find_index(record.record_id.to_s) || 100
+      end
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/spec/models/supplejack_api/record_spec.rb
+++ b/spec/models/supplejack_api/record_spec.rb
@@ -121,6 +121,15 @@ module SupplejackApi
         records = Record.find_multiple([r2.record_id, r1.record_id]).to_a
         expect(records.first).to eq r2
       end
+
+      context 'when record ids are passed as strings' do
+        it 'returns the records in the same order as requested' do
+          r1 = create(:record, created_at: Time.now.utc - 10.days)
+          r2 = create(:record, created_at: Time.now.utc)
+          records = Record.find_multiple([r2.record_id.to_s, r1.record_id.to_s]).to_a
+          expect(records.first).to eq r2
+        end
+      end
     end
 
     describe '#find_next_and_previous_records' do

--- a/spec/models/supplejack_api/record_spec.rb
+++ b/spec/models/supplejack_api/record_spec.rb
@@ -78,29 +78,19 @@ module SupplejackApi
     end
 
     describe '#find_multiple' do
-      before(:each) do
-        @record = create(:record)
-      end
+      let(:r1) { create(:record, created_at: Time.now.utc - 10.days) }
+      let(:r2) { create(:record, created_at: Time.now.utc) }
 
       it 'should find multiple records by numeric id' do
-        r1 = create(:record)
-        r2 = create(:record)
         expect(Record.find_multiple([r1.record_id, r2.record_id])).to include(r1, r2)
-        expect(Record.find_multiple([r1.record_id, r2.record_id]).length).to eq(2)
       end
 
       it 'should find multiple records by ObjectId' do
-        r1 = create(:record)
-        r2 = create(:record)
         expect(Record.find_multiple([r1.id, r2.id])).to include(r1, r2)
-        expect(Record.find_multiple([r1.id, r2.id]).length).to eq(2)
       end
 
       it "should find multiple records with ObjectId's and numeric id's" do
-        r1 = create(:record, record_id: 997)
-        r2 = create(:record)
         expect(Record.find_multiple([r1.record_id, r2.id])).to include(r1, r2)
-        expect(Record.find_multiple([r1.record_id, r2.id]).length).to eq(2)
       end
 
       it 'returns an empty array when ids is nil' do
@@ -108,34 +98,31 @@ module SupplejackApi
       end
 
       it 'should not return inactive records' do
-        r1 = create(:record, status: 'deleted')
-        r2 = create(:record, status: 'active')
-        records = Record.find_multiple([r1.record_id, r2.record_id]).to_a
-        expect(records).to_not include(r1)
+        inactive = create(:record, status: 'deleted')
+        records = Record.find_multiple([inactive.record_id, r2.record_id]).to_a
+
+        expect(records).to_not include(inactive)
         expect(records).to include(r2)
       end
 
       it 'returns the records in the same order as requested' do
-        r1 = create(:record, created_at: Time.now.utc - 10.days)
-        r2 = create(:record, created_at: Time.now.utc)
         records = Record.find_multiple([r2.record_id, r1.record_id]).to_a
+
         expect(records.first).to eq r2
       end
 
       context 'when record ids are passed as strings' do
         it 'returns the records in the same order as requested' do
-          r1 = create(:record, created_at: Time.now.utc - 10.days)
-          r2 = create(:record, created_at: Time.now.utc)
           records = Record.find_multiple([r2.record_id.to_s, r1.record_id.to_s]).to_a
+
           expect(records.first).to eq r2
         end
       end
 
       context 'when record ids are passed as strings & integers' do
         it 'returns the records in the same order as requested' do
-          r1 = create(:record, created_at: Time.now.utc - 10.days)
-          r2 = create(:record, created_at: Time.now.utc)
           records = Record.find_multiple([r2.record_id, r1.record_id.to_s]).to_a
+
           expect(records.first).to eq r2
         end
       end

--- a/spec/models/supplejack_api/record_spec.rb
+++ b/spec/models/supplejack_api/record_spec.rb
@@ -130,6 +130,15 @@ module SupplejackApi
           expect(records.first).to eq r2
         end
       end
+
+      context 'when record ids are passed as strings & integers' do
+        it 'returns the records in the same order as requested' do
+          r1 = create(:record, created_at: Time.now.utc - 10.days)
+          r2 = create(:record, created_at: Time.now.utc)
+          records = Record.find_multiple([r2.record_id, r1.record_id.to_s]).to_a
+          expect(records.first).to eq r2
+        end
+      end
     end
 
     describe '#find_next_and_previous_records' do


### PR DESCRIPTION
**Acceptance Criteria**
- /multiple.json route returns records in the same order they are asked for

**Bug**
This was only working if the model method received record_ids as integers as expected in the specs. However the controller always pass the ids as string.

**Fix**
- Since the ids can be a record_id or id of a record both string and integer values must be taken into account when sorting.
- A string version of the id is checked on sorting if the integer version dosent exist.