### PR TITLE
FIX REDUNDANT PARAMS IN STORIES API CALL

### DIFF
--- a/app/controllers/supplejack_api/story_items_controller.rb
+++ b/app/controllers/supplejack_api/story_items_controller.rb
@@ -83,7 +83,7 @@ module SupplejackApi
     end
 
     def item_params
-      params.require(:item).permit(
+      params.require(:story_item).permit(
         :position,
         :type,
         :sub_type,

--- a/spec/controllers/supplejack_api/story_items_controller_spec.rb
+++ b/spec/controllers/supplejack_api/story_items_controller_spec.rb
@@ -99,12 +99,12 @@ module SupplejackApi
                format: :json
 
           expect(response).to be_a_bad_request
-          expect(JSON.parse(response.body)['errors']).to eq 'Mandatory Parameter item missing in request'
+          expect(JSON.parse(response.body)['errors']).to eq 'Mandatory Parameter story_item missing in request'
         end
 
         it 'should return error for unknow values for type' do
           post :create,
-               params: { story_id: story.id.to_s, api_key: api_key, user_key: api_key, item: { type: 'foo' } },
+               params: { story_id: story.id.to_s, api_key: api_key, user_key: api_key, story_item: { type: 'foo' } },
                format: :json
 
           expect(response).to be_a_bad_request
@@ -117,7 +117,7 @@ module SupplejackApi
                  story_id: story.id.to_s,
                  api_key: api_key,
                  user_key: api_key,
-                 item: { type: 'text', sub_type: 'foo', content: { value: 'foo' } }
+                 story_item: { type: 'text', sub_type: 'foo', content: { value: 'foo' } }
                },
                format: :json
 
@@ -131,7 +131,7 @@ module SupplejackApi
                params: {
                  story_id: story.id.to_s,
                  api_key: api_key,
-                 user_key: api_key, item: { type: 'text', sub_type: 'heading' }
+                 user_key: api_key, story_item: { type: 'text', sub_type: 'heading' }
                }
 
           expect(response).to be_a_bad_request
@@ -150,7 +150,7 @@ module SupplejackApi
                  story_id: story.id.to_s,
                  api_key: api_key,
                  user_key: api_key,
-                 item: block
+                 story_item: block
                },
                format: :json
 
@@ -197,7 +197,7 @@ module SupplejackApi
 
           patch(:update, params: { story_id: story.id.to_s,
                                    id: story.set_items.first.id.to_s,
-                                   api_key: api_key, user_key: api_key, item: item })
+                                   api_key: api_key, user_key: api_key, story_item: item })
         end
 
         it 'returns a 200 http code' do

--- a/spec/requests/story_items_spec.rb
+++ b/spec/requests/story_items_spec.rb
@@ -122,12 +122,12 @@ RSpec.describe 'Story Items Endpoints', type: :request do
 
           response_attributes = JSON.parse(response.body)
 
-          expect(response_attributes).to eq({ 'errors' => 'Mandatory Parameter item missing in request' })
+          expect(response_attributes).to eq({ 'errors' => 'Mandatory Parameter story_item missing in request' })
         end
 
         context 'when item is text' do
           it 'returns error for missing type & sub_type' do
-            params = { item: { name: 'text' } }.to_query
+            params = { story_item: { name: 'text' } }.to_query
             post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
 
             response_attributes = JSON.parse(response.body)
@@ -136,7 +136,7 @@ RSpec.describe 'Story Items Endpoints', type: :request do
           end
 
           it 'returns error for missing content value' do
-            params = { item: { type: 'text', sub_type: 'heading' } }.to_query
+            params = { story_item: { type: 'text', sub_type: 'heading' } }.to_query
             post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
 
             response_attributes = JSON.parse(response.body)
@@ -145,7 +145,7 @@ RSpec.describe 'Story Items Endpoints', type: :request do
           end
 
           it 'returns error for size is not valid' do
-            params = { item: { type: 'text', sub_type: 'heading', content: { value: 'Heading text' }, meta: { size: 45 } } }.to_query
+            params = { story_item: { type: 'text', sub_type: 'heading', content: { value: 'Heading text' }, meta: { size: 45 } } }.to_query
             post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
 
             response_attributes = JSON.parse(response.body)
@@ -159,7 +159,7 @@ RSpec.describe 'Story Items Endpoints', type: :request do
             let(:record) { create(:record) }
 
             it 'returns success' do
-              params = { item: { type: 'embed', sub_type: 'record', record_id: record.record_id, content: { id: record.record_id }, meta: { alignment: 'left' } } }.to_query
+              params = { story_item: { type: 'embed', sub_type: 'record', record_id: record.record_id, content: { id: record.record_id }, meta: { alignment: 'left' } } }.to_query
               post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
 
               response_attributes = JSON.parse(response.body)
@@ -184,7 +184,7 @@ RSpec.describe 'Story Items Endpoints', type: :request do
 
           context 'when record id is passed wrongly' do
             it 'returns error for missing record id in content' do
-              params = { item: { type: 'embed', sub_type: 'record', content: { id: nil }, meta: { alignment: 'left' } } }.to_query
+              params = { story_item: { type: 'embed', sub_type: 'record', content: { id: nil }, meta: { alignment: 'left' } } }.to_query
               post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
 
               response_attributes = JSON.parse(response.body)
@@ -193,7 +193,7 @@ RSpec.describe 'Story Items Endpoints', type: :request do
             end
 
             it 'returns error for invalid id type' do
-              params = { item: { type: 'embed', sub_type: 'record', content: { id: 'i100' }, meta: { alignment: 'left' } } }.to_query
+              params = { story_item: { type: 'embed', sub_type: 'record', content: { id: 'i100' }, meta: { alignment: 'left' } } }.to_query
               post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
 
               response_attributes = JSON.parse(response.body)
@@ -209,7 +209,7 @@ RSpec.describe 'Story Items Endpoints', type: :request do
       let(:item) { story.set_items.first }
 
       it 'returns success' do
-        params = { item: { type: 'text', sub_type: 'heading', content: { value: 'Heading text' }, meta: { align_mode: 0 } } }.to_query
+        params = { story_item: { type: 'text', sub_type: 'heading', content: { value: 'Heading text' }, meta: { align_mode: 0 } } }.to_query
         post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
 
         response_attributes = JSON.parse(response.body)
@@ -221,7 +221,7 @@ RSpec.describe 'Story Items Endpoints', type: :request do
 
     context 'when adding rich text to story' do
       it 'returns success' do
-        params = { item: { type: 'text', sub_type: 'rich-text', content: { value: '<p>Some block content here</p>' }, meta: { align_mode: 0 } } }.to_query
+        params = { story_item: { type: 'text', sub_type: 'rich-text', content: { value: '<p>Some block content here</p>' }, meta: { align_mode: 0 } } }.to_query
         post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
 
         response_attributes = JSON.parse(response.body)
@@ -235,7 +235,7 @@ RSpec.describe 'Story Items Endpoints', type: :request do
       let(:record) { create(:record) }
 
       it 'returns success' do
-        params = { item: { type: 'embed', sub_type: 'record', record_id: record.record_id, content: { id: record.record_id }, meta: { align_mode: 0 } } }.to_query
+        params = { story_item: { type: 'embed', sub_type: 'record', record_id: record.record_id, content: { id: record.record_id }, meta: { align_mode: 0 } } }.to_query
         post "/v3/stories/#{story.id}/items.json?api_key=#{api_key}&user_key=#{story.user.api_key}&#{params}"
         response_attributes = JSON.parse(response.body)
 


### PR DESCRIPTION
**Acceptance Criteria**
Unwanted params are removed from the call.

**Issue**
When the controller name is not used to wrap the params that are send on a post/put method ParamsWrapper makes a copy of the params and adds them to params with a new key named after the controller name. This clutters the logs as the params are doubled. 

**Fix**
Fix is to follow Rails convention and used the same name as the controller for params.
