### PR TITLE
MORE LIKE THIS RESTRICTIONS: As Dan, I want MLT to be able to be scoped to only show the right records, so that natlib and other users can safely use MLT in their context

### DIFF
--- a/app/controllers/supplejack_api/concepts_controller.rb
+++ b/app/controllers/supplejack_api/concepts_controller.rb
@@ -9,7 +9,7 @@ module SupplejackApi
     respond_to :json, :xml, :rss
 
     def index
-      @search = ConceptSearch.new(params)
+      @search = ConceptSearch.new(params.to_unsafe_h)
       @search.request_url = request.original_url
       @search.scope = current_user
 

--- a/app/controllers/supplejack_api/records_controller.rb
+++ b/app/controllers/supplejack_api/records_controller.rb
@@ -86,8 +86,8 @@ module SupplejackApi
     def default_serializer_options
       default_options = {}
       @search ||= SupplejackApi::RecordSearch.new(all_params)
-      default_options[:fields] = @search.field_list if @search.field_list.present?
-      default_options[:groups] = @search.group_list if @search.group_list.present?
+      default_options[:fields] = @search.options.fields if @search.options.fields.present?
+      default_options[:groups] = @search.options.group_list if @search.options.group_list.present?
       default_options
     end
 

--- a/app/models/supplejack_api/concept.rb
+++ b/app/models/supplejack_api/concept.rb
@@ -3,6 +3,7 @@
 module SupplejackApi
   class Concept
     include Support::Concept::Storable
+    include Support::Searchable
     include Support::Concept::Searchable
 
     index({ concept_id: 1 }, background: true)

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -87,29 +87,29 @@ module SupplejackApi
 
       @search_builder ||= Sunspot.new_search(SupplejackApi::Record)
 
-      @search_builder = QueryBuilder::ExcludeFiltersFromFacets.new(@search_builder, options).call
-      @search_builder = QueryBuilder::Defaults.new(@search_builder).call
       @search_builder = QueryBuilder::RecordType.new(@search_builder, options.record_type).call
       @search_builder = QueryBuilder::Facets.new(@search_builder, options).call
       @search_builder = QueryBuilder::Spellcheck.new(@search_builder, options.suggest).call
       @search_builder = QueryBuilder::Without.new(@search_builder, options.without).call
       @search_builder = QueryBuilder::WithBoudingBox.new(@search_builder, options.geo_bbox).call
+      @search_builder = QueryBuilder::SolrQuery.new(@search_builder, options.solr_query).call
       @search_builder = QueryBuilder::FacetPivot.new(@search_builder, options.facet_pivots).call
-
-      surpressed_source_ids = SupplejackApi::Source.suppressed.all.pluck(:source_id)
-      @search_builder = QueryBuilder::Without.new(@search_builder, source_id: surpressed_source_ids).call
-
-      restrictions = self.class.role_collection_restrictions(scope)
-      @search_builder = QueryBuilder::Without.new(@search_builder, restrictions).call
-
+      @search_builder = QueryBuilder::Defaults.new(@search_builder).call
       @search_builder = QueryBuilder::FacetRow.new(@search_builder, options.facet_query).call
       @search_builder = QueryBuilder::Ordering.new(
         @search_builder, SupplejackApi::Record, options.sort, options.direction
       ).call
+
+      restrictions = self.class.role_collection_restrictions(scope)
+      @search_builder = QueryBuilder::Without.new(@search_builder, restrictions).call
+
+      surpressed_source_ids = SupplejackApi::Source.suppressed.all.pluck(:source_id)
+      @search_builder = QueryBuilder::Without.new(@search_builder, source_id: surpressed_source_ids).call
+
+      @search_builder = QueryBuilder::ExcludeFiltersFromFacets.new(@search_builder, options).call
       @search_builder = QueryBuilder::Paginate.new(@search_builder, options.page, options.per_page).call
-      @search_builder = QueryBuilder::SolrQuery.new(@search_builder, options.solr_query).call
-      @search_builder = QueryBuilder::Keywords.new(@search_builder, options.text, options.query_fields).call
       @search_builder.build(&build_conditions)
+      @search_builder = QueryBuilder::Keywords.new(@search_builder, options.text, options.query_fields).call
 
       @search_builder
     end

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -3,25 +3,14 @@
 # rubocop:disable Metrics/ClassLength
 module SupplejackApi
   class Search
+    attr_accessor :options, :request_url, :scope, :solr_request_params, :errors, :warnings
+
+    alias read_attribute_for_serialization send
+
     def initialize(options = {})
-      @options = options.dup
-      @options.reverse_merge!(
-        facets: '',
-        facet_pivots: '',
-        and: {},
-        or: {},
-        without: {},
-        page: 1,
-        per_page: 20,
-        record_type: 0,
-        facets_per_page: 10,
-        facets_page: 1,
-        sort: nil,
-        direction: 'desc',
-        exclude_filters_from_facets: false,
-        fields: 'default',
-        facet_query: {},
-        debug: nil
+      @original_options = options.dup
+      @options = SearchParams.new(
+        **options.merge(model_class: self.class.model_class, schema_class: self.class.schema_class)
       )
     end
 
@@ -33,119 +22,14 @@ module SupplejackApi
       "#{model_class.to_s.demodulize}Schema".constantize
     end
 
-    # Return an array of valid facets
-    # It will remove any invalid facets in order to avoid Solr errors
-    #
-    def facet_list
-      facet_list = options[:facets].split(',').map { |f| f.strip.to_sym }
-      facet_list.keep_if { |f| self.class.model_class.valid_facets.include?(f) }
-
-      # This is to prevent users from requesting integer and date fields as facets
-      # because we do not have docValues built up for these fields faceting does not work.
-      # We do not have docValues because we are experiencing an issue with the facet counts being wrong
-      # between different Solr replicas.
-      str_facets = %i[integer datetime]
-      facet_list.map do |facet|
-        if str_facets.include?(RecordSchema.fields[facet].type)
-          "#{facet}_str".to_sym
-        else
-          facet
-        end
-      end
-    end
-
-    def facet_pivot_list
-      return '' if options[:facet_pivots].blank?
-      return @facet_pivot_list if @facet_pivot_list
-
-      @facet_pivot_list =
-        options[:facet_pivots].split(',').map do |field|
-          field_facet = Sunspot.search(SupplejackApi::Record) do
-            json_facet(field.to_sym)
-          end.facets.first
-
-          field_facet.instance_eval('@field', __FILE__, __LINE__).indexed_name
-        rescue Sunspot::UnrecognizedFieldError
-          nil
-        end.compact.join(',')
-    end
-
-    def field_list
-      return @field_list if @field_list
-
-      valid_fields = self.class.schema_class.fields.keys.dup
-
-      @field_list = options[:fields].split(',').map { |f| f.strip.tr(':', '_').to_sym }
-      @field_list.delete_if do |f|
-        !valid_fields.include?(f)
-      end
-
-      @field_list
-    end
-
-    # Returns all valid groups of fields
-    # The groups are extracted from the "fields" parameter
-    #
-    def group_list
-      return @group_list if @group_list
-
-      @group_list = options[:fields].split(',').map { |f| f.strip.to_sym }
-      @group_list.keep_if { |f| self.class.model_class.valid_groups.include?(f) }
-      @group_list
-    end
-
-    def query_fields
-      query_field_list = nil
-
-      case options[:query_fields]
-      when String
-        query_field_list = options[:query_fields].split(',').map(&:strip).map(&:to_sym)
-      when Array
-        query_field_list = options[:query_fields].map(&:to_sym)
-      end
-
-      return nil if query_field_list&.empty?
-
-      query_field_list
-    end
-
-    def extract_range(value)
-      if value =~ /^\[(\d+)\sTO\s(\d+)\]$/
-        Regexp.last_match(1).to_i..Regexp.last_match(2).to_i
-      else
-        value.to_i.positive? ? value.to_i : value.strip
-      end
-    end
-
-    def to_proper_value(_name, value)
-      return false if value == 'false'
-      return true if value == 'true'
-      return nil if %w[nil null].include?(value)
-
-      value = value.strip if value.is_a?(String)
-      value
-    end
-
-    # Downcase all queries before sending to SOLR, except queries
-    # which have specific lucene syntax.
-    #
-    def text
-      @text = options[:text]
-
-      if @text.present? && !@text.match(/:"/)
-        @text = @text.downcase
-        @text.gsub!(/ and | or | not /, &:upcase)
-      end
-
-      @text
-    end
-
     def valid?
       self.errors ||= []
       self.warnings ||= []
-      self.class.max_values.each_key do |attribute|
-        max_value = self.class.max_values[attribute]
-        self.errors << "The #{attribute} parameter can not exceed #{max_value}" if @options[attribute].to_i > max_value
+      options.max_values.each_key do |attribute|
+        max_value = options.max_values[attribute]
+        if @original_options[attribute].to_i > max_value
+          self.errors << "The #{attribute} parameter can not exceed #{max_value}"
+        end
       end
 
       # This error comes from search_builder method.
@@ -165,7 +49,7 @@ module SupplejackApi
 
       @solr_search_object = execute_solr_search
 
-      if options[:debug] == 'true' && @solr_search_object.respond_to?(:query)
+      if options.debug && @solr_search_object.respond_to?(:query)
         self.solr_request_params = @solr_search_object.query.to_params
       end
 
@@ -176,7 +60,6 @@ module SupplejackApi
     # If not, spec it
     def execute_solr_search
       search = search_builder
-      search = QueryBuilder::Keywords.new(search, text, query_fields).call
 
       self.errors ||= []
       sunspot = search.execute
@@ -188,82 +71,49 @@ module SupplejackApi
       sunspot
     end
 
-    INTEGER_ATTRIBUTES ||= %i[page per_page facets_per_page facets_page record_type].freeze
-    alias read_attribute_for_serialization send
-
-    attr_accessor :options, :request_url, :scope, :solr_request_params, :errors, :warnings
-
-    class_attribute :max_values
-
-    self.max_values = {
-      page: 100_000,
-      per_page: 100,
-      facets_per_page: 350,
-      facets_page: 5000
-    }
-
     # The records that match the criteria within each role will be removed
     # from the search results
     #
     def self.role_collection_restrictions(scope)
-      restrictions = []
+      role = scope&.role&.to_sym
+      return [] if scope.blank? || schema_class.roles[role].record_restrictions.blank?
 
-      if scope
-        role = scope.role&.to_sym
-        restrictions = schema_class.roles[role].record_restrictions if schema_class.roles[role].record_restrictions
-      end
-
-      restrictions
+      schema_class.roles[role].record_restrictions
     end
 
-    # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
-    # FIXME: Make this method smaller, it's triple the max method length
     def search_builder
-      search_model = self
+      return @search_builder if @search_builder.present?
 
       @search_builder ||= Sunspot.new_search(SupplejackApi::Record)
 
-      @search_builder = QueryBuilder::ExcludeFiltersFromFacets.new(
-        @search_builder, options[:exclude_filters_from_facets], options[:and],
-        options[:or], facet_list, facets_per_page, facets_offset
-      ).call
+      @search_builder = QueryBuilder::ExcludeFiltersFromFacets.new(@search_builder, options).call
       @search_builder = QueryBuilder::Defaults.new(@search_builder).call
-      @search_builder = QueryBuilder::RecordType.new(@search_builder, options[:record_type]).call
-      @search_builder = QueryBuilder::Facets.new(@search_builder, facet_list, facets_per_page, facets_offset).call
-      @search_builder = QueryBuilder::Spellcheck.new(@search_builder, options[:suggest]).call
-      @search_builder = QueryBuilder::Without.new(@search_builder, without_params).call
-      @search_builder = QueryBuilder::WithBoudingBox.new(
-        @search_builder, options[:geo_bbox]&.split(',')&.map(&:to_f)
-      ).call
-      @search_builder = QueryBuilder::FacetPivot.new(@search_builder, facet_pivot_list).call
+      @search_builder = QueryBuilder::RecordType.new(@search_builder, options.record_type).call
+      @search_builder = QueryBuilder::Facets.new(@search_builder, options).call
+      @search_builder = QueryBuilder::Spellcheck.new(@search_builder, options.suggest).call
+      @search_builder = QueryBuilder::Without.new(@search_builder, options.without).call
+      @search_builder = QueryBuilder::WithBoudingBox.new(@search_builder, options.geo_bbox).call
+      @search_builder = QueryBuilder::FacetPivot.new(@search_builder, options.facet_pivots).call
 
       surpressed_source_ids = SupplejackApi::Source.suppressed.all.pluck(:source_id)
       @search_builder = QueryBuilder::Without.new(@search_builder, source_id: surpressed_source_ids).call
 
-      restrictions = search_model.class.role_collection_restrictions(search_model.scope)
+      restrictions = self.class.role_collection_restrictions(scope)
       @search_builder = QueryBuilder::Without.new(@search_builder, restrictions).call
 
-      @search_builder = QueryBuilder::FacetRow.new(@search_builder, options[:facet_query]).call
+      @search_builder = QueryBuilder::FacetRow.new(@search_builder, options.facet_query).call
       @search_builder = QueryBuilder::Ordering.new(
-        @search_builder, SupplejackApi::Record, options[:sort], options[:direction]
+        @search_builder, SupplejackApi::Record, options.sort, options.direction
       ).call
-      @search_builder = QueryBuilder::Paginate.new(@search_builder, options[:page], options[:per_page]).call
-      @search_builder = QueryBuilder::SolrQuery.new(@search_builder, options[:solr_query]).call
-
+      @search_builder = QueryBuilder::Paginate.new(@search_builder, options.page, options.per_page).call
+      @search_builder = QueryBuilder::SolrQuery.new(@search_builder, options.solr_query).call
+      @search_builder = QueryBuilder::Keywords.new(@search_builder, options.text, options.query_fields).call
       @search_builder.build(&build_conditions)
+
       @search_builder
     end
     # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
-
-    def without_params
-      return nil if options[:without].blank?
-
-      options[:without].map do |name, values|
-        [name, values.split(',').map { |value| to_proper_value(name, value) }.compact]
-      end.to_h
-    end
 
     # Returns the facets part of the search results converted to a hash
     #
@@ -283,29 +133,8 @@ module SupplejackApi
       facets
     end
 
-    def offset
-      (page * per_page) - per_page
-    end
-
-    def facets_offset
-      offset = (facets_page * facets_per_page) - facets_per_page
-      offset.negative? ? 0 : offset
-    end
-
     def records
       solr_search_object.results
-    end
-
-    # IMPORTANT !!!!
-    #
-    # Try to make this a bit prettier
-    #
-    INTEGER_ATTRIBUTES.each do |method|
-      define_method(method) do
-        value = @options[:"#{method.to_sym}"].to_i
-        value = [value, self.class.max_values[method]].min if self.class.max_values[method]
-        value
-      end
     end
 
     def method_missing(symbol, *args)
@@ -320,7 +149,7 @@ module SupplejackApi
     #
     def build_conditions
       proc do
-        { and: options[:and], or: options[:or] }.each do |operator, value|
+        { and: options.and_condition, or: options.or_condition }.each do |operator, value|
           Utils.call_block(self, &recurse_conditions(operator, value))
         end
       end
@@ -345,8 +174,10 @@ module SupplejackApi
             end
           end
         else
-          if options[:exclude_filters_from_facets] == 'true'
-            Utils.call_block(self, &filter_values(key, conditions, current_operator)) if facet_list.exclude?(key.to_sym)
+          if options.exclude_filters_from_facets
+            if options.facets.exclude?(key.to_sym)
+              Utils.call_block(self, &filter_values(key, conditions, current_operator))
+            end
           else
             Utils.call_block(self, &filter_values(key, conditions, current_operator))
           end
@@ -380,7 +211,7 @@ module SupplejackApi
         when /(.+)\*$/
           with(key).starting_with(Regexp.last_match(1))
         else
-          with(key, to_proper_value(key, values))
+          with(key, SearchParams.cast_param(key, values))
         end
       end
     end

--- a/app/params/supplejack_api/concerns/facets_pagination_params.rb
+++ b/app/params/supplejack_api/concerns/facets_pagination_params.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module FacetsPaginationParams
+      attr_reader :facets_page, :facets_per_page, :facets_offset
+
+      private
+
+      def init_facets_pagination(facets_page: 1, facets_per_page: 10, **_)
+        @facets_page = integer_param(:facets_page, facets_page.to_i)
+        @facets_per_page = integer_param(:facets_per_page, facets_per_page.to_i)
+        @facets_offset = (@facets_page * @facets_per_page) - @facets_per_page
+        @facets_offset = @facets_offset.negative? ? 0 : @facets_offset
+      end
+    end
+  end
+end

--- a/app/params/supplejack_api/concerns/facets_params.rb
+++ b/app/params/supplejack_api/concerns/facets_params.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module FacetsParams
+      attr_reader :facets, :facet_pivots, :facet_query
+
+      private
+
+      def init_facets(facets: '', facet_query: {}, facet_pivots: '', exclude_filters_from_facets: 'false', **_)
+        @facets = facets_param(facets)
+        @facet_query = facet_query
+        @exclude_filters_from_facets = exclude_filters_from_facets == 'true'
+        @facet_pivots = facet_pivots_param(facet_pivots)
+      end
+
+      # Return an array of valid facets
+      # It will remove any invalid facets in order to avoid Solr errors
+      #
+      def facets_param(facets_str)
+        facets_list = facets_str.split(',').map { |f| f.strip.to_sym }
+        facets_list.keep_if { |f| model_class.valid_facets.include?(f) }
+
+        # This is to prevent users from requesting integer and date fields as facets
+        # because we do not have docValues built up for these fields faceting does not work.
+        # We do not have docValues because we are experiencing an issue with the facet counts being wrong
+        # between different Solr replicas.
+        str_facets = %i[integer datetime]
+        facets_list.map do |facet|
+          if str_facets.include?(schema_class.fields[facet].type)
+            "#{facet}_str".to_sym
+          else
+            facet
+          end
+        end
+      end
+
+      def facet_pivots_param(facet_pivots_str)
+        return [] if facet_pivots_str.blank?
+
+        facet_pivots_str.split(',').map do |field|
+          field_facet = Sunspot.search(model_class) do
+            json_facet(field.to_sym)
+          end.facets.first
+
+          field_facet.instance_eval('@field', __FILE__, __LINE__).indexed_name
+        rescue Sunspot::UnrecognizedFieldError
+          nil
+        end.compact.join(',')
+      end
+    end
+  end
+end

--- a/app/params/supplejack_api/concerns/fields_params.rb
+++ b/app/params/supplejack_api/concerns/fields_params.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module FieldsParams
+      attr_reader :fields, :group_list, :query_fields
+
+      private
+
+      def init_fields(fields: 'default', query_fields: '', **_)
+        @fields = fields_param(fields)
+        @group_list = group_list_param(fields)
+        @query_fields = query_fields_param(query_fields)
+      end
+
+      def fields_param(fields_str)
+        valid_fields = schema_class.fields.keys.dup
+
+        field_list = fields_str.split(',').map { |f| f.strip.tr(':', '_').to_sym }
+        field_list & valid_fields
+      end
+
+      # Returns all valid groups of fields
+      # The groups are extracted from the "fields" parameter
+      #
+      def group_list_param(fields_str)
+        group_list = fields_str.split(',').map { |f| f.strip.to_sym }
+        group_list & model_class.valid_groups
+      end
+
+      def query_fields_param(query_fields)
+        query_field_list = []
+
+        case query_fields
+        when String
+          query_field_list = query_fields.split(',').map(&:strip).map(&:to_sym)
+        when Array
+          query_field_list = query_fields.map(&:to_sym)
+        end
+
+        query_field_list & schema_class.fields.keys
+      end
+    end
+  end
+end

--- a/app/params/supplejack_api/concerns/helpers_params.rb
+++ b/app/params/supplejack_api/concerns/helpers_params.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module HelpersParams
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def cast_param(_name, value)
+          return false if value == 'false'
+          return true if value == 'true'
+          return nil if %w[nil null].include?(value)
+
+          value = value.strip if value.is_a?(String)
+          value
+        end
+      end
+
+      private
+
+      included do
+        # Returns:
+        # - the default value if no value is provided
+        # - the corresponding max value if it is exceeding it
+        # - the value otherwise
+        def integer_param(param, value)
+          value = value.to_i
+          value = [value, self.class.max_values[param]].min if self.class.max_values[param]
+          value
+        end
+      end
+    end
+  end
+end

--- a/app/params/supplejack_api/concerns/model_schema_params.rb
+++ b/app/params/supplejack_api/concerns/model_schema_params.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module ModelSchemaParams
+      attr_reader :model_class, :schema_class
+
+      private
+
+      # this needs to be called first for the fields and facets params to work
+      def init_model_schema_params(model_class:, schema_class:, **_)
+        @model_class = model_class
+        @schema_class = schema_class
+      end
+    end
+  end
+end

--- a/app/params/supplejack_api/concerns/ordering_params.rb
+++ b/app/params/supplejack_api/concerns/ordering_params.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module OrderingParams
+      attr_reader :sort, :direction
+
+      private
+
+      def init_ordering(sort: nil, direction: 'desc', **_)
+        @sort = sort
+        @direction = direction
+      end
+    end
+  end
+end

--- a/app/params/supplejack_api/concerns/pagination_params.rb
+++ b/app/params/supplejack_api/concerns/pagination_params.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  module Concerns
+    module PaginationParams
+      attr_reader :page, :per_page, :offset
+
+      private
+
+      def init_pagination(page: 1, per_page: 20, **_)
+        @page = integer_param(:page, page.to_i)
+        @per_page = integer_param(:per_page, per_page.to_i)
+        @offset = (@page * @per_page) - @per_page
+      end
+    end
+  end
+end

--- a/app/params/supplejack_api/mlt_params.rb
+++ b/app/params/supplejack_api/mlt_params.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  class MltParams
+    include SupplejackApi::Concerns::ModelSchemaParams
+    include SupplejackApi::Concerns::PaginationParams
+    include SupplejackApi::Concerns::FieldsParams
+    include SupplejackApi::Concerns::HelpersParams
+
+    attr_reader(
+      :frequency,
+      :mlt_fields
+    )
+
+    class_attribute :max_values
+
+    self.max_values = {
+      page: 100_000,
+      per_page: 20
+    }
+
+    def initialize(**kwargs)
+      kwargs = kwargs.reverse_merge!(defaults).symbolize_keys
+
+      init_model_schema_params(**kwargs)
+      init_pagination(**kwargs)
+      init_fields(**kwargs)
+
+      @frequency = kwargs[:frequency]
+      @mlt_fields = mlt_fields_param(kwargs[:mlt_fields])
+    end
+
+    private
+
+    # this should also exclude fields with no mlt setup on the schema
+    def mlt_fields_param(mlt_fields_str)
+      return [] if mlt_fields_str.blank?
+
+      mlt_fields_str.split(',').map { |field| field.strip.to_sym }
+    end
+
+    def defaults
+      {
+        frequency: 1,
+        per_page: 5
+      }
+    end
+  end
+end

--- a/app/params/supplejack_api/mlt_params.rb
+++ b/app/params/supplejack_api/mlt_params.rb
@@ -16,7 +16,7 @@ module SupplejackApi
 
     self.max_values = {
       page: 100_000,
-      per_page: 20
+      per_page: 100
     }
 
     def initialize(**kwargs)

--- a/app/params/supplejack_api/search_params.rb
+++ b/app/params/supplejack_api/search_params.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module SupplejackApi
+  class SearchParams
+    include SupplejackApi::Concerns::ModelSchemaParams
+    include SupplejackApi::Concerns::PaginationParams
+    include SupplejackApi::Concerns::FacetsPaginationParams
+    include SupplejackApi::Concerns::OrderingParams
+    include SupplejackApi::Concerns::FieldsParams
+    include SupplejackApi::Concerns::FacetsParams
+    include SupplejackApi::Concerns::HelpersParams
+
+    attr_accessor(
+      :schema_class,
+      :model_class,
+      :geo_bbox,
+      :and_condition,
+      :or_condition,
+      :without,
+      :record_type,
+      :exclude_filters_from_facets,
+      :suggest,
+      :text,
+      :solr_query,
+      :debug
+    )
+
+    class_attribute :max_values
+
+    self.max_values = {
+      page: 100_000,
+      per_page: 100,
+      facets_per_page: 350,
+      facets_page: 5000
+    }
+
+    def initialize(**kwargs)
+      kwargs = kwargs.reverse_merge!(defaults).symbolize_keys
+
+      init_model_schema_params(**kwargs)
+      init_pagination(**kwargs)
+      init_facets_pagination(**kwargs)
+      init_ordering(**kwargs)
+      init_fields(**kwargs)
+      init_facets(**kwargs)
+
+      @suggest = kwargs[:suggest] == 'true'
+      @geo_bbox = geo_param(kwargs[:geo_bbox])
+      @text = text_param(kwargs[:text])
+      @and_condition = kwargs[:and]
+      @or_condition = kwargs[:or]
+      @without = without_param(kwargs[:without])
+      @record_type = kwargs[:record_type].to_i
+
+      @solr_query = kwargs[:solr_query]
+      @debug = kwargs[:debug] == 'true'
+    end
+
+    private
+
+    def without_param(without_param)
+      without_param.map do |name, values|
+        [name, values.split(',').map { |value| self.class.cast_param(name, value) }.compact]
+      end.to_h
+    end
+
+    # Downcase all queries before sending to SOLR, except queries
+    # which have specific lucene syntax.
+    #
+    def text_param(text)
+      return text.downcase.gsub(/ and | or | not /, &:upcase) unless text.match(/:"/)
+
+      text
+    end
+
+    def geo_param(param)
+      param.split(',').map(&:to_f)
+    end
+
+    def defaults
+      {
+        geo_bbox: '',
+        text: '',
+        and: {},
+        or: {},
+        without: {},
+        record_type: 0,
+        suggest: 'false',
+        solr_query: ''
+      }
+    end
+  end
+end

--- a/app/serializers/supplejack_api/search_serializer.rb
+++ b/app/serializers/supplejack_api/search_serializer.rb
@@ -12,9 +12,20 @@ module SupplejackApi
       ActiveModelSerializers::SerializableResource.new(object.results, options)
     end
 
-    attributes :per_page, :page, :request_url
+    attribute :page do
+      object.options.page
+    end
+
+    attribute :per_page do
+      object.options.per_page
+    end
+
+    attributes :request_url
+
     attribute :solr_request_params, if: -> { object.solr_request_params }
+
     attribute :warnings, if: -> { object.warnings.present? }
+
     attribute :facets do
       if xml?
         xml_facets

--- a/app/solr_queries/query/base.rb
+++ b/app/solr_queries/query/base.rb
@@ -12,7 +12,7 @@ module Query
     # from the search results
     #
     def role_collection_restrictions(role)
-      options.schema_class.roles[role]&.record_restrictions
+      options.schema_class.roles[role.to_sym]&.record_restrictions
     end
 
     def results

--- a/app/solr_queries/query/base.rb
+++ b/app/solr_queries/query/base.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Query
+  class Base
+    attr_reader :options
+
+    def initialize(options)
+      @options = options
+    end
+
+    # The records that match the criteria within each role will be removed
+    # from the search results
+    #
+    def role_collection_restrictions(role)
+      options.schema_class.roles[role]&.record_restrictions
+    end
+
+    def results
+      query.execute.results
+    end
+
+    private
+
+    def query
+      raise NotImplementedError, 'implement this in children classesr'
+    end
+  end
+end

--- a/app/solr_queries/query/more_like_this.rb
+++ b/app/solr_queries/query/more_like_this.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Query
+  class MoreLikeThis < Base
+    attr_reader :role, :record
+
+    def initialize(record, params, role)
+      super(SupplejackApi::MltParams.new(
+        **params.merge(
+          schema_class: RecordSchema, model_class: SupplejackApi::Record
+        )
+      ))
+      @record = record
+      @role = role
+    end
+
+    private
+
+    def query
+      search = Sunspot.new_more_like_this(record)
+      search = QueryBuilder::Paginate.new(search, options.page, options.per_page).call
+      search = QueryBuilder::Fields.new(search, options.mlt_fields).call
+      search = QueryBuilder::MinimumTermFrequency.new(search, options.frequency).call
+      QueryBuilder::Without.new(search, role_collection_restrictions(role)).call
+    end
+  end
+end

--- a/app/solr_queries/query/more_like_this.rb
+++ b/app/solr_queries/query/more_like_this.rb
@@ -21,7 +21,10 @@ module Query
       search = QueryBuilder::Paginate.new(search, options.page, options.per_page).call
       search = QueryBuilder::Fields.new(search, options.mlt_fields).call
       search = QueryBuilder::MinimumTermFrequency.new(search, options.frequency).call
-      QueryBuilder::Without.new(search, role_collection_restrictions(role)).call
+      search = QueryBuilder::Without.new(search, role_collection_restrictions(role)).call
+
+      surpressed_source_ids = SupplejackApi::Source.suppressed.all.pluck(:source_id)
+      QueryBuilder::Without.new(search, source_id: surpressed_source_ids).call
     end
   end
 end

--- a/app/solr_queries/query_builder/base.rb
+++ b/app/solr_queries/query_builder/base.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class Base
+    attr_reader :search, :this
+
+    def initialize(search)
+      @search = search
+    end
+
+    def call
+      @this = self
+    end
+
+    def cast_param(_name, value)
+      return false if value == 'false'
+      return true if value == 'true'
+      return nil if %w[nil null].include?(value)
+
+      value = value.strip if value.is_a?(String)
+      value
+    end
+  end
+end

--- a/app/solr_queries/query_builder/defaults.rb
+++ b/app/solr_queries/query_builder/defaults.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class Defaults < Base
+    def call
+      super
+
+      search.build do
+        adjust_solr_params do |params|
+          params['q.op'] = 'AND'
+          params['df'] = 'text'
+          params['sow'] = 'true'
+          params['facet.threads'] = ENV['SOLR_FACET_THREADS']&.to_i || 4
+        end
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/exclude_filters_from_facets.rb
+++ b/app/solr_queries/query_builder/exclude_filters_from_facets.rb
@@ -4,37 +4,29 @@ module QueryBuilder
   class ExcludeFiltersFromFacets < Base
     attr_reader(
       :exclude_filters_from_facets,
-      :and_conditions,
-      :or_conditions,
+      :and_condition,
+      :or_condition,
       :facet_list,
       :facets_per_page,
       :facets_offset
     )
 
-    def initialize(
-      search,
-      exclude_filters_from_facets,
-      and_conditions,
-      or_conditions,
-      facet_list,
-      facets_per_page,
-      facets_offset
-    )
+    def initialize(search, params)
       super(search)
 
-      @exclude_filters_from_facets = exclude_filters_from_facets
-      @and_conditions = and_conditions
-      @or_conditions = or_conditions
-      @facet_list = facet_list
-      @facets_per_page = facets_per_page
-      @facets_offset = facets_offset
+      @exclude_filters_from_facets = params.exclude_filters_from_facets
+      @and_condition = params.and_condition
+      @or_condition = params.or_condition
+      @facet_list = params.facets
+      @facets_per_page = params.facets_per_page
+      @facets_offset = params.facets_offset
     end
 
     def call
       super
-      return search if exclude_filters_from_facets != 'true'
+      return search unless exclude_filters_from_facets
 
-      or_and_options = {}.merge(and_conditions).merge(or_conditions).symbolize_keys
+      or_and_options = {}.merge(and_condition).merge(or_condition).symbolize_keys
 
       # This is to clean up any valid integer or date facets that have been requested
       # Through the filter options, so that they are treated as strings.

--- a/app/solr_queries/query_builder/exclude_filters_from_facets.rb
+++ b/app/solr_queries/query_builder/exclude_filters_from_facets.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class ExcludeFiltersFromFacets < Base
+    attr_reader(
+      :exclude_filters_from_facets,
+      :and_conditions,
+      :or_conditions,
+      :facet_list,
+      :facets_per_page,
+      :facets_offset
+    )
+
+    def initialize(
+      search,
+      exclude_filters_from_facets,
+      and_conditions,
+      or_conditions,
+      facet_list,
+      facets_per_page,
+      facets_offset
+    )
+      super(search)
+
+      @exclude_filters_from_facets = exclude_filters_from_facets
+      @and_conditions = and_conditions
+      @or_conditions = or_conditions
+      @facet_list = facet_list
+      @facets_per_page = facets_per_page
+      @facets_offset = facets_offset
+    end
+
+    def call
+      super
+      return search if exclude_filters_from_facets != 'true'
+
+      or_and_options = {}.merge(and_conditions).merge(or_conditions).symbolize_keys
+
+      # This is to clean up any valid integer or date facets that have been requested
+      # Through the filter options, so that they are treated as strings.
+      str_facets = %i[integer datetime]
+      converted_string_facets = or_and_options.each_with_object([]) do |(facet_name, _facet_value), array|
+        array.push(facet_name) if str_facets.include?(RecordSchema.fields[facet_name.to_sym]&.type)
+      end
+
+      converted_string_facets.each do |facet|
+        or_and_options["#{facet}_str".to_sym] = or_and_options.delete(facet)
+      end
+
+      search.build do
+        or_and_options.slice(*facet_list).each do |facet_name, value|
+          facet(
+            facet_name.to_sym,
+            exclude: with_query_for_facet_exclusion(self, facet_name.to_sym, value),
+            limit: facets_per_page,
+            offset: facets_offset
+          )
+        end
+      end
+    end
+
+    private
+
+    def with_query_for_facet_exclusion(search_context, facet_name, value)
+      # Necessary to pass search_context in order to generate `with` queries
+      wildcard_search_term_regex = /(.+)\*$/ # search term ends in *
+
+      if value =~ wildcard_search_term_regex
+        search_context.with(facet_name).starting_with(Regexp.last_match(1))
+      elsif value.is_a?(Hash) && value.key?(:or)
+        search_context.with(facet_name, value[:or])
+      else
+        # Value is a non-wildcarded string, or an array
+        search_context.with(facet_name, value)
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/facet_pivot.rb
+++ b/app/solr_queries/query_builder/facet_pivot.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class FacetPivot < Base
+    attr_reader :facet_pivot_list
+
+    def initialize(search, facet_pivot_list)
+      super(search)
+
+      @facet_pivot_list = facet_pivot_list
+    end
+
+    def call
+      super
+      return search if facet_pivot_list.blank?
+
+      adjust_solr_params do |params|
+        params['facet.pivot'] = facet_pivot_list
+        params['facet'] = 'on'
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/facet_row.rb
+++ b/app/solr_queries/query_builder/facet_row.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  # Facet Queries
+  #
+  # The facet query parameter should have the following format:
+  #
+  #   facet_query: {images: {"creator" => "all"}, headings: {"record_type" => 1}}
+  #
+  # - Each key in the top level hash will be the name of each facet row returned.
+  # - Each value in the top level hash is a hash similar with all the restrictions
+  class FacetRow < Base
+    attr_reader :facet_query
+
+    def initialize(search, facet_query)
+      super(search)
+
+      @facet_query = facet_query
+    end
+
+    def call
+      super
+      return search if facet_query.blank?
+
+      search.build do
+        facet(:counts) do
+          facet_query.each_pair do |row_name, filters_hash|
+            row(row_name.to_s) do
+              filters_hash.each_pair do |filter, value|
+                if value == 'all'
+                  without(filter.to_sym, nil)
+                elsif filter =~ /-(.+)/
+                  without(Regexp.last_match(1).to_sym, this.cast_param(filter, value))
+                elsif value.is_a?(Array)
+                  with(filter.to_sym).all_of(value)
+                else
+                  with(filter.to_sym, this.cast_param(filter, value))
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/facets.rb
+++ b/app/solr_queries/query_builder/facets.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  # Facet Queries
+  #
+  # The facet query parameter should have the following format:
+  #
+  #   facet_query: {images: {"creator" => "all"}, headings: {"record_type" => 1}}
+  #
+  # - Each key in the top level hash will be the name of each facet row returned.
+  # - Each value in the top level hash is a hash similar with all the restrictions
+  class Facets < Base
+    attr_reader :facet_list, :facets_per_page, :facets_offset
+
+    def initialize(search, facet_list, facets_per_page, facets_offset)
+      super(search)
+
+      @facet_list = facet_list
+      @facets_per_page = facets_per_page
+      @facets_offset = facets_offset
+    end
+
+    def call
+      super
+      return search if facet_list.blank?
+
+      search.build do
+        facet_list.each do |facet_name|
+          facet(facet_name, limit: facets_per_page, offset: facets_offset)
+        end
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/facets.rb
+++ b/app/solr_queries/query_builder/facets.rb
@@ -12,12 +12,12 @@ module QueryBuilder
   class Facets < Base
     attr_reader :facet_list, :facets_per_page, :facets_offset
 
-    def initialize(search, facet_list, facets_per_page, facets_offset)
+    def initialize(search, params)
       super(search)
 
-      @facet_list = facet_list
-      @facets_per_page = facets_per_page
-      @facets_offset = facets_offset
+      @facet_list = params.facets
+      @facets_per_page = params.facets_per_page
+      @facets_offset = params.facets_offset
     end
 
     def call

--- a/app/solr_queries/query_builder/fields.rb
+++ b/app/solr_queries/query_builder/fields.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class Fields < Base
+    attr_reader :fields_array
+
+    def initialize(search, fields)
+      super(search)
+
+      @fields_array = fields
+    end
+
+    def call
+      super
+
+      search.build do
+        fields(*fields_array)
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/keywords.rb
+++ b/app/solr_queries/query_builder/keywords.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class Keywords < Base
+    attr_reader :text, :query_fields
+
+    def initialize(search, text, query_fields)
+      super(search)
+
+      @text = text
+      @query_fields = query_fields
+    end
+
+    def call
+      super
+      return search if text.blank?
+
+      search.build do
+        keywords text, fields: query_fields
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/minimum_term_frequency.rb
+++ b/app/solr_queries/query_builder/minimum_term_frequency.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class MinimumTermFrequency < Base
+    attr_reader :frequency
+
+    def initialize(search, frequency)
+      super(search)
+
+      @frequency = frequency
+    end
+
+    def call
+      super
+
+      search.build do
+        minimum_term_frequency frequency
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/ordering.rb
+++ b/app/solr_queries/query_builder/ordering.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class Ordering < Base
+    attr_reader :model_class, :order_by, :order_direction
+
+    def initialize(search, model_class, order_by, order_direction)
+      super(search)
+
+      @order_by = order_by
+      @model_class = model_class
+      @order_direction = order_direction
+    end
+
+    def call
+      super
+      return search if order_by.blank?
+
+      model_class = self
+      search.build do
+        order_by(model_class.order_by_attribute, model_class.direction)
+      end
+    end
+
+    def order_by_attribute
+      value = order_by.to_sym
+
+      begin
+        Sunspot::Setup.for(model_class).field(value)
+        value
+      rescue Sunspot::UnrecognizedFieldError
+        :score
+      end
+    end
+
+    def direction
+      if %w[asc desc].include?(order_direction)
+        order_direction.to_sym
+      else
+        :desc
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/paginate.rb
+++ b/app/solr_queries/query_builder/paginate.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class Paginate < Base
+    attr_reader :page, :per_page
+
+    def initialize(search, page, per_page)
+      super(search)
+
+      @page = page
+      @per_page = per_page
+    end
+
+    def call
+      super
+
+      search.build do
+        paginate page: page, per_page: per_page
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/record_type.rb
+++ b/app/solr_queries/query_builder/record_type.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class RecordType < Base
+    attr_reader :record_type
+
+    def initialize(search, record_type)
+      super(search)
+
+      @record_type = record_type
+    end
+
+    def call
+      super
+
+      search.build do
+        with(:record_type, record_type) unless record_type == 'all'
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/solr_query.rb
+++ b/app/solr_queries/query_builder/solr_query.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class SolrQuery < Base
+    attr_reader :query
+
+    def initialize(search, query)
+      super(search)
+
+      @query = query
+    end
+
+    def call
+      super
+      return search if query.blank?
+
+      search.build do
+        adjust_solr_params do |params|
+          params[:q] ||= ''
+          params['q.alt'] = query
+          params[:defType] = 'dismax'
+        end
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/spellcheck.rb
+++ b/app/solr_queries/query_builder/spellcheck.rb
@@ -12,7 +12,7 @@ module QueryBuilder
 
     def call
       super
-      return search if spellcheck.blank?
+      return search unless spellcheck
 
       search.build do
         spellcheck collate: true, only_more_popular: true

--- a/app/solr_queries/query_builder/spellcheck.rb
+++ b/app/solr_queries/query_builder/spellcheck.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class Spellcheck < Base
+    attr_reader :spellcheck
+
+    def initialize(search, spellcheck)
+      super(search)
+
+      @spellcheck = spellcheck
+    end
+
+    def call
+      super
+      return search if spellcheck.blank?
+
+      search.build do
+        spellcheck collate: true, only_more_popular: true
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/with_bouding_box.rb
+++ b/app/solr_queries/query_builder/with_bouding_box.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class WithBoudingBox < Base
+    attr_reader :coords
+
+    def initialize(search, coords)
+      super(search)
+
+      @coords = coords
+    end
+
+    def call
+      super
+      return search if coords.blank?
+
+      search.build do
+        with(:lat_lng).in_bounding_box([coords[2], coords[1]], [coords[0], coords[3]])
+      end
+    end
+  end
+end

--- a/app/solr_queries/query_builder/without.rb
+++ b/app/solr_queries/query_builder/without.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module QueryBuilder
+  class Without < Base
+    attr_reader :without_hash
+
+    def initialize(search, without_hash)
+      super(search)
+
+      @without_hash = without_hash
+    end
+
+    def call
+      super
+      return search if without_hash.blank?
+
+      search.build do
+        without_hash.each do |field, values|
+          without(field.to_sym, values)
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 require 'sidekiq/web'
-Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
 
 SupplejackApi::Engine.routes.draw do
   root to: 'records#index', defaults: {format: 'json'}

--- a/spec/controllers/supplejack_api/concepts_controller_spec.rb
+++ b/spec/controllers/supplejack_api/concepts_controller_spec.rb
@@ -35,7 +35,6 @@ module SupplejackApi
       before do
         @search = ConceptSearch.new
         allow(@search).to receive(:valid?) { false }
-        allow(@search).to receive(:new) { @search }
       end
 
       it 'initializes a new search instance' do

--- a/spec/controllers/supplejack_api/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/records_controller_spec.rb
@@ -247,21 +247,19 @@ module SupplejackApi
     end
 
     describe '#default_serializer_options' do
-      before(:each) do
+      it 'should return a hash with info for serialization' do
         @search = RecordSearch.new
         allow(RecordSearch).to receive(:new) { @search }
-      end
 
-      it 'should return a hash with info for serialization' do
         controller.default_serializer_options
         expect(assigns(:search)).to eq(@search)
       end
 
       it 'should merge in the search fields' do
-        allow(@search).to receive(:field_list).and_return(%i[title description])
-        allow(@search).to receive(:group_list).and_return([:verbose])
+        @search = RecordSearch.new(fields: 'title,description,verbose')
+        allow(RecordSearch).to receive(:new) { @search }
 
-        expect(controller.default_serializer_options).to eq(fields: %i[title description], groups: [:verbose])
+        expect(controller.default_serializer_options).to eq(fields: %i[title description], groups: %i[verbose])
       end
     end
 

--- a/spec/controllers/supplejack_api/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/records_controller_spec.rb
@@ -218,9 +218,7 @@ module SupplejackApi
       before(:each) do
         @record = create(:record)
         allow(controller).to receive(:current_user) { @user }
-        allow(RecordSchema).to receive(:roles) { { developer: developer_restriction } }
-        allow(Record).to receive(:custom_find).with(@record.id).and_return(@record)
-        allow(@record).to receive(:more_like_this).and_return(double(:mlt, results: [@record]))
+        allow_any_instance_of(Query::MoreLikeThis).to receive(:results).and_return([@record])
       end
 
       context 'json' do

--- a/spec/dummy/app/supplejack_api/record_schema.rb
+++ b/spec/dummy/app/supplejack_api/record_schema.rb
@@ -7,7 +7,7 @@ class RecordSchema
   # Fields
   string    :record_id, store: false
   string    :name,         search_boost: 10,      search_as: [:filter, :fulltext], namespace: :dc
-  string    :title,         search_boost: 10,      search_as: [:filter, :fulltext], namespace: :dc
+  string    :title,        search_boost: 10,      search_as: [:filter, :fulltext, :mlt], namespace: :dc
   string    :address,      search_boost: 2,       search_as: [:filter, :fulltext]
   string    :email,        multi_value: true,     search_as: [:filter]
   string    :children,     multi_value: true
@@ -22,7 +22,7 @@ class RecordSchema
   string    :content_partner, multi_value: true,                                                          namespace: :dc
   string    :creator,     multi_value: true,    search_as: [:filter, :fulltext],  namespace: :dc
   string    :contributing_partner,  multi_value: true,    search_as: [:fulltext], namespace: :dc
-  string    :subject,                       multi_value: true,    search_as: [:filter, :fulltext],  namespace: :dc
+  string    :subject,                       multi_value: true,    search_as: [:filter, :fulltext, :mlt],  namespace: :dc
   # facets
   string    :category,     multi_value: true,     search_as: [:filter]
   string    :copyright,    multi_value: true,     search_as: [:filter]

--- a/spec/models/supplejack_api/record_search_spec.rb
+++ b/spec/models/supplejack_api/record_search_spec.rb
@@ -216,9 +216,8 @@ module SupplejackApi
         @search.options[:without] = { email: 'jd@example.com, johnd@test.com', name: 'James Cook' }
         @search.execute_solr_search
         expect(@session).to have_search_params(:without, proc do
-          without(:email, 'jd@example.com')
-          without(:email, 'johnd@test.com')
-          without(:name, 'James Cook')
+          without(:email, ['jd@example.com', 'johnd@test.com'])
+          without(:name, ['James Cook'])
         end)
       end
 
@@ -397,7 +396,7 @@ module SupplejackApi
       it 'removes blacklisted collections from results' do
         create(:source, source_id: 'DNZ', status: 'suppressed')
         @search.execute_solr_search
-        expect(@session).to have_search_params(:without, :source_id, 'DNZ')
+        expect(@session).to have_search_params(:without, :source_id, ['DNZ'])
       end
 
       it 'defaults to exclude_filters_from_facets == false' do

--- a/spec/models/supplejack_api/record_search_spec.rb
+++ b/spec/models/supplejack_api/record_search_spec.rb
@@ -8,8 +8,6 @@ module SupplejackApi
       @search = RecordSearch.new
       Sunspot.session = SunspotMatchers::SunspotSessionSpy.new(Sunspot.session)
       @session = Sunspot.session
-
-      allow(RecordSearch).to receive(:role_collection_restrictions) { [] }
     end
 
     describe '.role_collection_restrictions' do
@@ -19,7 +17,6 @@ module SupplejackApi
       let(:no_restriction)        { double(:no_restriction, record_restrictions: nil) }
 
       before(:each) do
-        allow(RecordSearch).to receive(:role_collection_restrictions).and_call_original
         allow(RecordSchema).to receive(:roles) { { admin: no_restriction, developer: developer_restriction } }
       end
 
@@ -44,6 +41,10 @@ module SupplejackApi
       let(:names)     { %w[John James] }
       let(:addresses) { ['Te Aro', 'Brooklyn'] }
 
+      before do
+        allow(RecordSearch).to receive(:role_collection_restrictions) { [] }
+      end
+
       context 'solr errors' do
         before do
           @sunspot_builder = double(:sunspot_builder).as_null_object
@@ -51,7 +52,7 @@ module SupplejackApi
         end
 
         it 'rescues from a bad request error' do
-          allow(@sunspot_builder).to receive(:execute).and_raise(RSolr::Error::Http.new({}, nil))
+          expect(@sunspot_builder).to receive(:execute).and_raise(RSolr::Error::Http.new({}, nil))
           @search.execute_solr_search
         end
 
@@ -65,92 +66,75 @@ module SupplejackApi
       end
 
       it 'should call keywords method with user input' do
-        @search.options[:text] = 'dog'
-        @search.execute_solr_search
+        RecordSearch.new(text: 'dog').execute_solr_search
         expect(@session).to have_search_params(:keywords, 'dog')
       end
 
       it 'downcases the user entered text' do
-        @search.options[:text] = 'Dog'
-        @search.execute_solr_search
+        RecordSearch.new(text: 'Dog')
+        RecordSearch.new(text: 'Dog').execute_solr_search
         expect(@session).to have_search_params(:keywords, 'dog')
       end
 
       it "doesn't downcase SOLR operators" do
-        @search.options[:text] = 'dog NOT beach'
-        @search.execute_solr_search
+        RecordSearch.new(text: 'dog NOT beach').execute_solr_search
         expect(@session).to have_search_params(:keywords, 'dog NOT beach')
       end
 
       it "doesn't upcase words containing solr operators" do
-        @search.options[:text] = 'New Zealand'
-        @search.execute_solr_search
+        RecordSearch.new(text: 'New Zealand').execute_solr_search
         expect(@session).to have_search_params(:keywords, 'new zealand')
       end
 
-      # rubocop:disable Style/StringLiterals
       it "doesn't downcase when targeting a specific field" do
-        @search.options[:text] = "name_sm:\"John Doe\""
-        @search.execute_solr_search
+        RecordSearch.new(text: 'name_sm:"John Doe"').execute_solr_search
 
-        expect(@session).to have_search_params(:keywords, "name_sm:\"John Doe\"")
+        expect(@session).to have_search_params(:keywords, 'name_sm:"John Doe"')
       end
-      # rubocop:enable Style/StringLiterals
 
       it 'restricts the query fields to name' do
-        @search.options[:text] = 'dog'
-        @search.options[:query_fields] = [:name]
-        @search.execute_solr_search
+        RecordSearch.new(text: 'dog', query_fields: [:name]).execute_solr_search
         expect(query_fields_for_search.split(' ').sort).to eq ['name_text']
       end
 
       it 'restricts to multiple query fields' do
-        @search.options[:text] = 'dog'
-        @search.options[:query_fields] = %i[name address]
-        @search.execute_solr_search
+        RecordSearch.new(text: 'dog', query_fields: %i[name address]).execute_solr_search
         expect(query_fields_for_search.split(' ').sort).to eq %w[address_text name_text]
       end
 
       it 'should search for all text fields' do
-        @search.options[:text] = 'dog'
-        @search.execute_solr_search
+        RecordSearch.new(text: 'dog').execute_solr_search
         expect(query_fields_for_search.split(' ').sort).to include('address_text', 'name_text')
       end
 
       it "should not use the query fields if text isn't present" do
-        @search.options[:query_fields] = %i[name address]
-        @search.execute_solr_search
+        RecordSearch.new(query_fields: %i[name address]).execute_solr_search
         expect(query_fields_for_search).to be_nil
       end
 
       it 'should add any facets in the :facets parameter' do
-        @search.options[:facets] = 'name, address'
-        @search.execute_solr_search
+        RecordSearch.new(facets: 'name, address').execute_solr_search
         expect(@session).to have_search_params(:facet, :name)
         expect(@session).to have_search_params(:facet, :address)
       end
 
       it 'should limit the amount of facet values' do
-        @search.options.merge!(facets: 'name', facets_per_page: 10)
-        @search.execute_solr_search
+        RecordSearch.new(facets: 'name', facets_per_page: 10).execute_solr_search
         expect(@session).to have_search_params(:facet, proc { facet(:name, limit: 10) })
       end
 
       it 'should offset the facets returned' do
-        @search.options.merge!(facets: 'name', facets_per_page: 10, facets_page: 2)
-        @search.execute_solr_search
+        RecordSearch.new(facets: 'name', facets_per_page: 10, facets_page: 2).execute_solr_search
         expect(@session).to have_search_params(:facet, proc { facet(:name, offset: 10) })
       end
 
       it 'should restrict results by facet values' do
-        @search.options[:and] = { address: 'Wellington' }
-        @search.execute_solr_search
+        RecordSearch.new(and: { address: 'Wellington' }).execute_solr_search
         expect(@session).to have_search_params(:with, :address, 'Wellington')
       end
 
       it 'should restrict results by multiple facet values' do
-        @search.options[:and] = { name: 'John Doe', address: 'Wellington' }
-        @search.execute_solr_search
+        RecordSearch.new(and: { name: 'John Doe', address: 'Wellington' }).execute_solr_search
         expect(@session).to have_search_params(:with, proc do
           all_of do
             with(:name, 'John Doe')
@@ -160,8 +144,7 @@ module SupplejackApi
       end
 
       it 'should preserve commas in facet values' do
-        @search.options[:and] = { address: '12 Smith St, Te Aro, Wellington' }
-        @search.execute_solr_search
+        RecordSearch.new(and: { address: '12 Smith St, Te Aro, Wellington' }).execute_solr_search
         expect(@session).to have_search_params(:with, proc do
           all_of do
             with(:address, '12 Smith St, Te Aro, Wellington')
@@ -170,40 +153,34 @@ module SupplejackApi
       end
 
       it 'should restrict result by multiple facet values if an array is passed' do
-        @search.options[:and] = { email: ['jd@example.com', 'johnd@test.com'] }
-        @search.execute_solr_search
+        RecordSearch.new(and: { email: ['jd@example.com', 'johnd@test.com'] }).execute_solr_search
 
         expect(@session)
           .to have_search_params(:with, proc { with(:email).all_of(['jd@example.com', 'johnd@test.com']) })
       end
 
       it 'converts the string true to a real true' do
-        @search.options[:and] = { nz_citizen: 'true' }
-        @search.execute_solr_search
+        RecordSearch.new(and: { nz_citizen: 'true' }).execute_solr_search
         expect(@session).to have_search_params(:with, :nz_citizen, true)
       end
 
       it 'converts the string false to a real false' do
-        @search.options[:and] = { nz_citizen: 'false' }
-        @search.execute_solr_search
+        RecordSearch.new(and: { nz_citizen: 'false' }).execute_solr_search
         expect(@session).to have_search_params(:with, :nz_citizen, false)
       end
 
       it 'executes a prefix query when a star(*) is at the end of the value' do
-        @search.options[:and] = { name: 'John*' }
-        @search.execute_solr_search
+        RecordSearch.new(and: { name: 'John*' }).execute_solr_search
         expect(@session).to have_search_params(:with, proc { with(:name).starting_with('John') })
       end
 
       it 'ignores a prefix query if the star(*) is not at the end' do
-        @search.options[:and] = { name: '*John' }
-        @search.execute_solr_search
+        RecordSearch.new(and: { name: '*John' }).execute_solr_search
         expect(@session).to have_search_params(:with, :name, '*John')
       end
 
       it 'should return results matching any of the facet values' do
-        @search.options[:or] = { email: ['jd@example.com', 'johnd@test.com'], name: 'James Cook' }
-        @search.execute_solr_search
+        RecordSearch.new(or: { email: ['jd@example.com', 'johnd@test.com'], name: 'James Cook' }).execute_solr_search
         expect(@session).to have_search_params(:with, proc do
           any_of do
             with(:email).any_of(['jd@example.com', 'johnd@test.com'])
@@ -213,8 +190,7 @@ module SupplejackApi
       end
 
       it 'should not return results matching the facet values' do
-        @search.options[:without] = { email: 'jd@example.com, johnd@test.com', name: 'James Cook' }
-        @search.execute_solr_search
+        RecordSearch.new(without: { email: 'jd@example.com, johnd@test.com', name: 'James Cook' }).execute_solr_search
         expect(@session).to have_search_params(:without, proc do
           without(:email, ['jd@example.com', 'johnd@test.com'])
           without(:name, ['James Cook'])
@@ -222,31 +198,27 @@ module SupplejackApi
       end
 
       it 'should return results with any value' do
-        @search.options[:without] = { address: 'nil' }
-        @search.execute_solr_search
+        RecordSearch.new(without: { address: 'nil' }).execute_solr_search
         expect(@session).to have_search_params(:without, :address, nil)
       end
 
       it 'should sort by the specified field' do
-        @search.options[:sort] = 'name'
-        @search.execute_solr_search
+        RecordSearch.new(sort: 'name').execute_solr_search
         expect(@session).to have_search_params(:order_by, :name, :desc)
       end
 
       it 'should not sort when not specified' do
-        @search.options[:sort] = ''
-        @search.execute_solr_search
+        RecordSearch.new(sort: '').execute_solr_search
         expect(@session).to_not have_search_params(:order_by, any_param)
       end
 
       it 'should default to page 1 and 20 per page' do
-        @search.execute_solr_search
+        RecordSearch.new.execute_solr_search
         expect(@session).to have_search_params(:paginate, page: 1, per_page: 20)
       end
 
       it 'should change the page and per_page defaults' do
-        @search.options.merge!(page: 3, per_page: 40)
-        @search.execute_solr_search
+        RecordSearch.new(page: 3, per_page: 40).execute_solr_search
         expect(@session).to have_search_params(:paginate, page: 3, per_page: 40)
       end
 
@@ -268,8 +240,7 @@ module SupplejackApi
       end
 
       it 'should add the lucene string to the solr :q.alt parameter' do
-        @search.options.merge!(solr_query: 'title:dogs')
-        @search.execute_solr_search
+        RecordSearch.new(solr_query: 'title:dogs').execute_solr_search
 
         alt = @session.searches.last.last.instance_variable_get(:@query).to_params['q.alt']
         expect(alt).to eq('title:dogs')
@@ -277,14 +248,12 @@ module SupplejackApi
 
       context 'nested queries' do
         it 'joins name values with a OR query' do
-          @search.options[:and] = { name: { or: names } }
-          @search.execute_solr_search
+          RecordSearch.new(and: { name: { or: names } }).execute_solr_search
           expect(@session).to have_search_params(:with, proc { with(:name).any_of(names) })
         end
 
         it 'joins two facets with OR but values within each filter with AND' do
-          @search.options[:or] = { name: { and: names }, address: { and: addresses } }
-          @search.execute_solr_search
+          RecordSearch.new(or: { name: { and: names }, address: { and: addresses } }).execute_solr_search
           expect(@session).to have_search_params(:with, proc do
             any_of do
               with(:name).all_of(names)
@@ -294,8 +263,12 @@ module SupplejackApi
         end
 
         it 'joins two AND conditions with OR, one AND condition contains multiple fields' do
-          @search.options[:or] = { name: { and: names }, and: { address: 'Wellington', nz_citizen: 'true' } }
-          @search.execute_solr_search
+          RecordSearch.new(
+            or: {
+              name: { and: names },
+              and: { address: 'Wellington', nz_citizen: 'true' }
+            }
+          ).execute_solr_search
           expect(@session).to have_search_params(:with, proc do
             any_of do
               with(:name).all_of(names)
@@ -308,12 +281,12 @@ module SupplejackApi
         end
 
         it 'nesting OR and AND conditions 3 levels deep' do
-          @search.options[:and] = {
-            name: 'John',
-            or: { address: 'Wellington', and: { nz_citizen: 'true', email: 'john@test.com' } }
-          }
-
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: {
+              name: 'John',
+              or: { address: 'Wellington', and: { nz_citizen: 'true', email: 'john@test.com' } }
+            }
+          ).execute_solr_search
 
           expect(@session).to have_search_params(:with, proc do
             all_of do
@@ -330,9 +303,10 @@ module SupplejackApi
         end
 
         it 'joins options[:and] and options[:or] conditions with AND' do
-          @search.options[:and] = { name: { or: names }, nz_citizen: 'true' }
-          @search.options[:or] = { address: addresses }
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: { name: { or: names }, nz_citizen: 'true' },
+            or: { address: addresses }
+          ).execute_solr_search
           expect(@session).to have_search_params(:with, proc do
             all_of do
               all_of do
@@ -345,8 +319,13 @@ module SupplejackApi
         end
 
         it 'nests multiple filters with :or queries in their values' do
-          @search.options[:and] = { name: { or: names }, nz_citizen: 'true', address: { or: addresses } }
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: {
+              name: { or: names },
+              nz_citizen: 'true',
+              address: { or: addresses }
+            }
+          ).execute_solr_search
           expect(@session).to have_search_params(:with, proc do
             all_of do
               with(:name).any_of(names)
@@ -363,32 +342,27 @@ module SupplejackApi
         end
 
         it 'queries for all of given facet' do
-          @search.options.merge!({ facet_query: { email: { email: 'all' } } })
-          @search.execute_solr_search
+          RecordSearch.new({ facet_query: { email: { email: 'all' } } }).execute_solr_search
           expect(facet_query_params).to eq('email_sm:[* TO *]')
         end
 
         it 'queries for records with name "John"' do
-          @search.options.merge!({ facet_query: { people: { name: 'John' } } })
-          @search.execute_solr_search
+          RecordSearch.new({ facet_query: { people: { name: 'John' } } }).execute_solr_search
           expect(facet_query_params).to eq('name_s:John')
         end
 
         it 'queries for records without name "James"' do
-          @search.options.merge!({ facet_query: { people: { '-name' => 'James' } } })
-          @search.execute_solr_search
+          RecordSearch.new({ facet_query: { people: { '-name' => 'James' } } }).execute_solr_search
           expect(facet_query_params).to eq('-name_s:James')
         end
 
         it 'correctly reads a "false" value' do
-          @search.options.merge!({ facet_query: { citizens: { nz_citizen: 'false' } } })
-          @search.execute_solr_search
+          RecordSearch.new({ facet_query: { citizens: { nz_citizen: 'false' } } }).execute_solr_search
           expect(facet_query_params).to eq('nz_citizen_b:false')
         end
 
         it 'queries for records with category Images and Videos' do
-          @search.options.merge!({ facet_query: { people: { name: names  } } })
-          @search.execute_solr_search
+          RecordSearch.new({ facet_query: { people: { name: names  } } }).execute_solr_search
           expect(facet_query_params).to eq('name_s:(John AND James)')
         end
       end
@@ -401,18 +375,16 @@ module SupplejackApi
 
       it 'defaults to exclude_filters_from_facets == false' do
         @search.execute_solr_search
-        expect(@search.options[:exclude_filters_from_facets]).to be_falsey
+        expect(@search.options.exclude_filters_from_facets).to eq false
       end
 
       context 'exclude_filters_from_facets == true' do
-        before do
-          @search.options[:exclude_filters_from_facets] = 'true'
-        end
-
         it 'exclude filters from ORed facets' do
-          @search.options[:or] = { name: names, address: addresses }
-          @search.options[:facets] = 'name, address'
-          @search.execute_solr_search
+          RecordSearch.new(
+            or: { name: names, address: addresses },
+            facets: 'name, address',
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
 
           expect(@session).to have_search_params(:facet) {
             name_filter = with(:name, names)
@@ -424,9 +396,11 @@ module SupplejackApi
         end
 
         it 'exclude filters from ANDed facets' do
-          @search.options[:and] = { name: names, address: addresses }
-          @search.options[:facets] = 'name, address'
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: { name: names, address: addresses },
+            facets: 'name, address',
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
 
           expect(@session).to have_search_params(:facet) {
             name_filter = with(:name, names)
@@ -438,30 +412,30 @@ module SupplejackApi
         end
 
         it 'excludes filters from AND filters if there are OR filters nested inside' do
-          subjects = %w[Birds Plants]
-          categories = %w[Image Video]
-          and_query = {
-            subject: { or: subjects },
-            category: { or: categories }
-          }
-
-          @search.options[:and] = and_query
-          @search.options[:facets] = and_query.keys.join(', ')
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: {
+              subject: { or: %w[Birds Plants] },
+              category: { or: %w[Image Video] }
+            },
+            facets: 'subject,category',
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
 
           expect(@session).to have_search_params(:facet) {
-            subject_filter = with(:subject, subjects)
+            subject_filter = with(:subject, %w[Birds Plants])
             facet(:subject, exclude: subject_filter)
 
-            category_filter = with(:category, categories)
+            category_filter = with(:category, %w[Image Video])
             facet(:category, exclude: category_filter)
           }
         end
 
         it 'does not add additional facets into the search' do
-          @search.options[:and] = { category: ['Audio'], subject: ['forest'] }
-          @search.options[:facets] = 'category'
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: { category: ['Audio'], subject: ['forest'] },
+            facets: 'category',
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
 
           expect(@session).to have_search_params(:facet) {
             category_filter = with(:category, ['Audio'])
@@ -475,8 +449,10 @@ module SupplejackApi
         end
 
         it 'does not add facets into the search when you aren\'t asking for any' do
-          @search.options[:and] = { category: ['Audio'], subject: ['forest'] }
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: { category: ['Audio'], subject: ['forest'] },
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
 
           expect(@session).not_to have_search_params(:facet) {
             category_filter = with(:category, ['Audio'])
@@ -490,9 +466,11 @@ module SupplejackApi
         end
 
         it 'handles integer facets correctly' do
-          @search.options[:and] = { age: ['10'], subject: ['forest'] }
-          @search.options[:facets] = 'age'
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: { age: ['10'], subject: ['forest'] },
+            facets: 'age',
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
 
           expect(@session).to have_search_params(:facet) {
             age_filter = with(:age_str, ['10'])
@@ -501,24 +479,26 @@ module SupplejackApi
         end
 
         it 'applies filters that are given as strings via the URL correctly' do
-          categories = %w[Images]
-          @search.options[:and] = { category: categories }
-          @search.options[:facets] = 'subject, category'
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: { category: %w[Images] },
+            facets: 'subject, category',
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
 
           expect(@session).to have_search_params(:facet) {
-            category_filter = with(:category, categories)
+            category_filter = with(:category, %w[Images])
             facet(:category, exclude: category_filter)
           }
         end
 
         it 'applies filters that are given which are not facets' do
-          categories = %w[Images]
-          @search.options[:and] = { category: categories }
-          @search.options[:facets] = 'subject'
-          @search.execute_solr_search
+          RecordSearch.new(
+            and: { category: %w[Images] },
+            facets: 'subject',
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
 
-          expect(@session).to have_search_params(:with, :category, categories)
+          expect(@session).to have_search_params(:with, :category, %w[Images])
           expect(@session).to have_search_params(:facet, :subject)
           expect(@session).not_to have_search_params(:facet, :category)
         end

--- a/spec/params/search_params_spec.rb
+++ b/spec/params/search_params_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module SupplejackApi
+  describe SearchParams do
+    describe '#cast_param' do
+      it 'returns false for "false" string' do
+        expect(SearchParams.cast_param('active?', 'false')).to be_falsey
+      end
+
+      it 'returns true for "true" string' do
+        expect(SearchParams.cast_param('active?', 'true')).to be_truthy
+      end
+
+      it 'returns nil if is a "nil" string' do
+        expect(SearchParams.cast_param('active?', 'nil')).to be_nil
+      end
+
+      it 'returns nil if is a "null" string' do
+        expect(SearchParams.cast_param('active?', 'null')).to be_nil
+      end
+
+      it 'returns the value unchanged' do
+        expect(SearchParams.cast_param('label', 'Black')).to eq('Black')
+      end
+
+      it 'should strip any white space' do
+        expect(SearchParams.cast_param('label', ' Black Label ')).to eq('Black Label')
+      end
+    end
+  end
+end


### PR DESCRIPTION
[MORE LIKE THIS RESTRICTIONS: As Dan, I want MLT to be able to be scoped to only show the right records, so that natlib and other users can safely use MLT in their context](https://www.pivotaltracker.com/story/show/181734061)

STORY
=====

**Acceptance Criteria**
- Can be scoped to only show natlib, or another CP's content 
- Total records limited to 100
- Reindex all staging data 
- Check in with Dan about approach 

**Risks**
- ?

**Notes**
-  Can use [scope](https://www.rubydoc.info/gems/sunspot/1.3.3/Sunspot/DSL/Scope)  or [query](https://www.rubydoc.info/gems/sunspot/1.3.3/Sunspot/DSL/Search) in more_like_this with restrictions added to API user role. 
- Ideally its tied in as natively as possible so that if natlib were to use MLT. It would use the same scoping mechanism as the site itself. eg the API key role, or ... not actually sure exactly how natlib scopes to only natlib content does it.
- The other scenario is if CEISMIC, or an NZmuseum site were to only want to show MLT of their own content.
