### PR TITLE
INDEXING TOO MUCH AND NOT ENOUGH: As Dan, I want the indexer to run effectively and efficiently, so that it reliably indexes all the right records, the right amount of times

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ For more information on how to configure and use this application refer to the [
 
 [Install & Setup instructions](http://digitalnz.github.io/supplejack/start/development-setup.html)
 
-
 ## Swagger Documentation
 
 [Stories Api](https://swaggerhub.com/api/DigitalNZ/supplejack-stories-api/3.0.0)
@@ -49,11 +48,7 @@ bundle exec rake app:sunspot:solr:stop
 
 ### Rspec Specs
 
-From the root of the engine, run
-
-```
-bundle exec rspec spec/
-```
+From the root of the engine, run `bundle exec rspec spec/`
 
 This uses `spec/dummy` to mount the engine into and then runs the specs.
 

--- a/app/models/supplejack_api/search.rb
+++ b/app/models/supplejack_api/search.rb
@@ -103,8 +103,8 @@ module SupplejackApi
       restrictions = self.class.role_collection_restrictions(scope)
       @search_builder = QueryBuilder::Without.new(@search_builder, restrictions).call
 
-      surpressed_source_ids = SupplejackApi::Source.suppressed.all.pluck(:source_id)
-      @search_builder = QueryBuilder::Without.new(@search_builder, source_id: surpressed_source_ids).call
+      suppressed_source_ids = SupplejackApi::Source.suppressed.all.pluck(:source_id)
+      @search_builder = QueryBuilder::Without.new(@search_builder, source_id: suppressed_source_ids).call
 
       @search_builder = QueryBuilder::ExcludeFiltersFromFacets.new(@search_builder, options).call
       @search_builder = QueryBuilder::Paginate.new(@search_builder, options.page, options.per_page).call

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -45,8 +45,7 @@ class BatchIndexRecords
 
   def update_unless_changed(records)
     SupplejackApi::Record.where(
-      :record_id.in => records.map(&:record_id),
-      :updated_at.in => records.map(&:updated_at)
+      :record_id.in => records.map(&:record_id)
     ).update_all(index_updated: true, index_updated_at: Time.current)
   end
 end

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/Output
 class BatchIndexRecords
   attr_reader :records, :failed_records
 
@@ -23,7 +24,6 @@ class BatchIndexRecords
 
   private
 
-  # rubocop:disable Rails/Output
   # Call Sunspot index in the array provided, if failure,
   # retry each record individually to be indexed and log errors
   def retry_index_records(records)
@@ -42,7 +42,6 @@ class BatchIndexRecords
   ensure
     update_unless_changed([record])
   end
-  # rubocop:enable Rails/Output
 
   def update_unless_changed(records)
     SupplejackApi::Record.where(
@@ -51,3 +50,4 @@ class BatchIndexRecords
     ).update_all(index_updated: true, index_updated_at: Time.current)
   end
 end
+# rubocop:enable Rails/Output

--- a/app/solr_queries/query/more_like_this.rb
+++ b/app/solr_queries/query/more_like_this.rb
@@ -23,8 +23,8 @@ module Query
       search = QueryBuilder::MinimumTermFrequency.new(search, options.frequency).call
       search = QueryBuilder::Without.new(search, role_collection_restrictions(role)).call
 
-      surpressed_source_ids = SupplejackApi::Source.suppressed.all.pluck(:source_id)
-      QueryBuilder::Without.new(search, source_id: surpressed_source_ids).call
+      suppressed_source_ids = SupplejackApi::Source.suppressed.all.pluck(:source_id)
+      QueryBuilder::Without.new(search, source_id: suppressed_source_ids).call
     end
   end
 end

--- a/app/workers/supplejack_api/flush_old_records_worker.rb
+++ b/app/workers/supplejack_api/flush_old_records_worker.rb
@@ -38,7 +38,7 @@ module SupplejackApi
       SupplejackApi::Record.where(
         :'fragments.source_id' => source_id,
         :'fragments.job_id'.ne => job_id,
-        :status.in => %w[active supressed],
+        :status.in => %w[active suppressed],
         'fragments.priority': 0
       ).update_all(status: 'deleted', updated_at: Time.now.utc)
     end

--- a/lib/supplejack_api/index_processor.rb
+++ b/lib/supplejack_api/index_processor.rb
@@ -3,35 +3,35 @@
 # rubocop:disable Rails/Output
 module SupplejackApi
   class IndexProcessor
+    def initialize(batch_size = 500)
+      @batch_size = batch_size
+    end
+
     def call
       index_available_records
-
       unindex_available_records
     end
 
-    def index_available_records
-      p 'Looking for records to index..' unless Rails.env.test?
+    private
 
-      records = indexable_records
-      while records.count.positive?
+    def index_available_records
+      p 'Looking for records to index...' unless Rails.env.test?
+
+      indexable_records.batch_size(@batch_size).each_slice(@batch_size) do |records|
         p "[#{Time.current}] #{records.count} to be indexed: #{records.map(&:record_id)}" unless Rails.env.test?
+        p "[#{Time.current}] #{records.count} to be indexed: #{records.map(&:updated_at)}" unless Rails.env.test?
 
         BatchIndexRecords.new(records).call
-
-        records = indexable_records
       end
     end
 
     def unindex_available_records
       p 'Looking for records to unindex..' unless Rails.env.test?
 
-      records = SupplejackApi::Record.ready_for_indexing.where(:status.ne => 'active').limit(500).to_a
-      while records.count.positive?
-        p "[#{Time.current}] There are #{records.count} records to be removed from the index.." unless Rails.env.test?
+      unindexable_records.batch_size(@batch_size).each_slice(@batch_size) do |records|
+        p "[#{Time.current}] There are #{records.count} records to be removed from the index..." unless Rails.env.test?
 
         BatchRemoveRecordsFromIndex.new(records).call
-
-        records = SupplejackApi::Record.ready_for_indexing.where(:status.ne => 'active').limit(500.to_a)
       end
     end
 
@@ -48,7 +48,11 @@ module SupplejackApi
         .where(
           status: 'active',
           'fragments.source_id' => { '$nin' => source_ids }
-        ).limit(500).to_a
+        )
+    end
+
+    def unindexable_records
+      SupplejackApi::Record.ready_for_indexing.where(:status.ne => 'active')
     end
   end
 end

--- a/lib/supplejack_api/index_processor.rb
+++ b/lib/supplejack_api/index_processor.rb
@@ -19,8 +19,8 @@ module SupplejackApi
 
       indexable_records.batch_size(@batch_size).each_slice(@batch_size) do |records|
         p "[#{Time.current}] #{records.count} to be indexed: #{records.map(&:record_id)}" unless Rails.env.test?
-        p "[#{Time.current}] #{records.count} to be indexed: #{records.map(&:updated_at)}" unless Rails.env.test?
 
+        p "[#{Time.current}] debug: #{records.map { |r| "#{r.record_id}/#{r.updated_at.strftime('%H:%M:%S.%L')}" }.join(', ')}"
         BatchIndexRecords.new(records).call
       end
     end

--- a/lib/tasks/index_processor.rb
+++ b/lib/tasks/index_processor.rb
@@ -3,14 +3,12 @@
 require 'rake'
 
 namespace :index_processor do
-  task run: :environment do
+  task :run, [:batch_size] => [:environment] do |_, args|
+    batch_size = args.fetch(:batch_size, 500).to_i
+
     loop do
-      fork do
-        SupplejackApi::IndexProcessor.new.call
-      end
-
+      fork { SupplejackApi::IndexProcessor.new(batch_size).call }
       Process.wait
-
       sleep 30
     end
   end

--- a/spec/controllers/supplejack_api/harvester/concepts_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/concepts_controller_spec.rb
@@ -41,13 +41,13 @@ module SupplejackApi
 
     #   it 'finds the record and assigns it' do
     #     expect(Concept).to receive(:custom_find).with('123', nil, {status: :all}) { concept }
-    #     put :update, id: 123, concept: { status: 'supressed' }, format: :json
+    #     put :update, id: 123, concept: { status: 'suppressed' }, format: :json
     #     expect(assigns(:concept)).to eq(concept)
     #   end
 
     #   it "updates the status of the record" do
-    #     expect(concept).to receive(:update_attribute).with(:status, 'supressed')
-    #     put :update, id: 123, concept: { status: 'supressed' }, format: :json
+    #     expect(concept).to receive(:update_attribute).with(:status, 'suppressed')
+    #     put :update, id: 123, concept: { status: 'suppressed' }, format: :json
     #   end
     # end
   end

--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -141,13 +141,13 @@ module SupplejackApi
 
         it 'finds the record and asigns it' do
           expect(Record).to receive(:custom_find).with('123', nil, { status: :all }) { record }
-          put :update, params: { id: 123, record: { status: 'supressed' }, api_key: harvester.api_key }, format: :json
+          put :update, params: { id: 123, record: { status: 'suppressed' }, api_key: harvester.api_key }, format: :json
           expect(assigns(:record)).to eq(record)
         end
 
         it 'updates the status of the record and marks it for indexing' do
-          expect(record).to receive(:update).with(status: 'supressed')
-          put :update, params: { id: 123, record: { status: 'supressed' }, api_key: harvester.api_key }, format: :json
+          expect(record).to receive(:update).with(status: 'suppressed')
+          put :update, params: { id: 123, record: { status: 'suppressed' }, api_key: harvester.api_key }, format: :json
         end
       end
 
@@ -248,7 +248,7 @@ module SupplejackApi
 
       describe 'PUT update' do
         it 'returns unauthorized' do
-          put :update, params: { id: 'abc123', record: { status: 'supressed' }, api_key: user.api_key }, format: :json
+          put :update, params: { id: 'abc123', record: { status: 'suppressed' }, api_key: user.api_key }, format: :json
 
           expect(response).to be_unauthorized
         end

--- a/spec/models/supplejack_api/user_set_spec.rb
+++ b/spec/models/supplejack_api/user_set_spec.rb
@@ -638,7 +638,7 @@ module SupplejackApi
         context 'record status' do
           let(:user_set) { build(:user_set) }
 
-          it 'should default the status to supressed' do
+          it 'should default the status to suppressed' do
             user_set.privacy = 'private'
 
             user_set.update_record

--- a/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
+++ b/spec/workers/supplejack_api/flush_old_records_worker_spec.rb
@@ -39,9 +39,9 @@ module SupplejackApi
         create(:record, status: 'active', fragments: fragments)
       end
 
-      let!(:supressed_record) do
+      let!(:suppressed_record) do
         fragments = build_list(:record_fragment, 1, priority: 0, job_id: old_job_id, source_id: source_id)
-        create(:record, status: 'supressed', fragments: fragments)
+        create(:record, status: 'suppressed', fragments: fragments)
       end
 
       let!(:deleted_record) do
@@ -59,7 +59,7 @@ module SupplejackApi
         create(:record, status: 'active', fragments: fragments)
       end
 
-      it 'should delete all active/supressed records that were not harvest by a specific job' do
+      it 'should delete all active/suppressed records that were not harvest by a specific job' do
         FlushOldRecordsWorker.new.flush_records(source_id, current_job_id)
         expect(SupplejackApi::Record.deleted.count).to eq 3
       end


### PR DESCRIPTION
[INDEXING TOO MUCH AND NOT ENOUGH: As Dan, I want the indexer to run effectively and efficiently, so that it reliably indexes all the right records, the right amount of times](https://www.pivotaltracker.com/story/show/182068934)

STORY
=====

**Acceptance Criteria**
- [REDUNDANT INDEXING] Records are not indexed multiple times unnecessarily
- [MISSING RECORDS] All updated records are reliably indexed

**Risks**
- The index process is very important.

**Notes**
- Dan has had a feeling that indexing has been taking longer than usual for a while now, even though the indexer seems very busy.
- Tim (and other harvester) have been complaining of missing records during indexing.
- I grabbed all the listed record_id's being indexed with in 1 minute. There were 8 logs of 500 id's each. Out of those accumulated 4000 id's, only 1156 were unique in that 1 minute.
(I dont know if the log entries themselves are duplicated?)
- I did another bigger havest and loaded all the id's from the indexing logs into excel and ran a de-dup process:
>14402 duplicate values found and removed; 2493 unique values remain.

**Testing REDUNDANT INDEXING**
- Take a look at the [indexing logs](https://kibana.digitalnz.org/goto/0ee13840-99c9-11ec-a275-bf1241a27651)
- Zoom in on some indexing activity until there's a bunch of lists of 500 record_id's shown.
- Notice that there is a lot of duplication

**Testing MISSING RECORDS**
- On [this test parser](https://manager.digitalnz.org/parsers/558b3bea297b1fc90f000003/versions/62786cd8f1d8d86b9f6cd031) change the prefixed word on line 22 (so that it doesnt match existing records and creates new ones)
- Save and tag for staging, then run the harvest as a Full and Flush
- Check the API to make sure your prefix change to the internal_identifier has come through and that the numbers match
https://api.staging.digitalnz.org/records.json?&api_key=v0aORgQAmQDSPtOJzMGI&text=source_id_s%3Adave_test&fields=verbose,internal_identifier&debug=true
- If the problem has happened, you should see some records missing (eg only 2419 out of the expected 2,518)
- OPTIONAL: check in mongo for any active records from source_id:dave_test that have not been indexed, or try and find them in there.
- Once you've waited long enough and you're sure they're not gonna show, go to this page https://manager.digitalnz.org/sources/533b6397745448cda7000003/edit and press the "Reindex data source" button, and then press it again on the popup
- This will pick up the missing records, showing that they are in Mongo, and something has gone wrong with the indexing process
