### PR TITLE
MODERATE HIDDEN STORY: As DNZ admin, I want to be able to moderate Hidden stories, so that they can be accepted too.

### DIFF
--- a/app/policies/supplejack_api/user_set_policy.rb
+++ b/app/policies/supplejack_api/user_set_policy.rb
@@ -18,9 +18,9 @@ module SupplejackApi
     end
 
     def show?
-      return true unless @story.private?
+      return true if admin_or_owner?
 
-      @story.user == @user || @user&.admin?
+      @story.approved? && !@story.private?
     end
 
     alias index?        admin?

--- a/spec/factories/story.rb
+++ b/spec/factories/story.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     name            { 'Story name' }
     description     { 'Story description' }
     featured        { false }
-    approved        { false }
+    approved        { true }
     tags            { %w[story tags] }
     copyright       { 0 }
     cover_thumbnail { 'https://thumbnail_url' }

--- a/spec/policies/supplejack_api/user_set_policy_spec.rb
+++ b/spec/policies/supplejack_api/user_set_policy_spec.rb
@@ -35,11 +35,21 @@ RSpec.describe SupplejackApi::UserSetPolicy, type: :policy do
     end
 
     context 'when the story is public' do
-      let(:story) { create(:story, privacy: 'public') }
+      let(:story) { create(:story, privacy: 'public', approved: true) }
 
       context 'when user is not and admin or owner of story' do
         it 'grants access' do
           expect(policy).to permit(user, story)
+        end
+      end
+    end
+
+    context 'when the story is not approved' do
+      let(:story) { create(:story, privacy: 'hidden', approved: false) }
+
+      context 'when user is not and admin or owner of story' do
+        it 'grants access' do
+          expect(policy).not_to permit(user, story)
         end
       end
     end


### PR DESCRIPTION
- When Story is private, it will only be available for admins and story owner
- Otherwise, it will only be publicly available if the story has been approved