### PR TITLE
FIX DUPLICATED INDEXING JOBS: As Dan, I want to fix the records being indexed multiple times, so that we reduce the load on Solr and mongo

### DIFF
--- a/lib/supplejack_api/index_processor.rb
+++ b/lib/supplejack_api/index_processor.rb
@@ -10,6 +10,9 @@ module SupplejackApi
       log('Looking for records...')
       index_available_records
       unindex_available_records
+    rescue StandardError => e
+      log('Failed run:')
+      log(e)
     end
 
     private

--- a/lib/supplejack_api/index_processor.rb
+++ b/lib/supplejack_api/index_processor.rb
@@ -7,7 +7,7 @@ module SupplejackApi
     end
 
     def call
-      log('Looking for records...', false)
+      log('Looking for records...')
       index_available_records
       unindex_available_records
     end
@@ -61,7 +61,7 @@ module SupplejackApi
     def log(str, prefix = '')
       return if Rails.env.test?
 
-      prefix = "[#{Time.current}] [#{Process.pid}/#{Process.ppid}] " if prefix
+      prefix = "[#{Time.current}] [#{Process.pid}/#{Process.ppid}] " if prefix.present?
       p "#{prefix}#{str}"
     end
     # rubocop:enable Rails/Output

--- a/lib/supplejack_api/index_processor.rb
+++ b/lib/supplejack_api/index_processor.rb
@@ -10,9 +10,6 @@ module SupplejackApi
       log('Looking for records...')
       index_available_records
       unindex_available_records
-    rescue StandardError => e
-      log('Failed run:')
-      log(e)
     end
 
     private

--- a/lib/tasks/index_processor.rb
+++ b/lib/tasks/index_processor.rb
@@ -7,8 +7,7 @@ namespace :index_processor do
     batch_size = args.fetch(:batch_size, 500).to_i
 
     loop do
-      fork { SupplejackApi::IndexProcessor.new(batch_size).call }
-      Process.wait
+      SupplejackApi::IndexProcessor.new(batch_size).call
       sleep 30
     end
   end

--- a/lib/tasks/index_processor.rb
+++ b/lib/tasks/index_processor.rb
@@ -12,7 +12,7 @@ namespace :index_processor do
       rescue StandardError => e
         Rails.logger.error(e)
       end
-      Process.wait
+      Rails.logger.info "Finished forks #{Process.waitall}"
       sleep 30
     end
   end

--- a/lib/tasks/index_processor.rb
+++ b/lib/tasks/index_processor.rb
@@ -7,7 +7,12 @@ namespace :index_processor do
     batch_size = args.fetch(:batch_size, 500).to_i
 
     loop do
-      SupplejackApi::IndexProcessor.new(batch_size).call
+      fork do
+        SupplejackApi::IndexProcessor.new(batch_size).call
+      rescue StandardError => e
+        Rails.logger.error(e)
+      end
+      Process.wait
       sleep 30
     end
   end


### PR DESCRIPTION
[FIX DUPLICATED INDEXING JOBS: As Dan, I want to fix the records being indexed multiple times, so that we reduce the load on Solr and mongo](https://www.pivotaltracker.com/story/show/182490794)

STORY
=====

**Acceptance Criteria**
- Records are being picked up by the indexer only once per harvest

**Risks**
- <Any risks?>

**Notes**
- Paul has identified that a fork (?) seems to be causing multiple processes/job to be doing the same batch of indexing
- Follows https://www.pivotaltracker.com/story/show/182068934

**Tests**
- Records are displayed only once the in the logs https://kibana.digitalnz.org/goto/36588250-ed8b-11ec-a955-f10266d237d8
