### PR TITLE
AUTHORITY INDEXING BUG

### DIFF
--- a/spec/services/update_record_from_harvest_spec.rb
+++ b/spec/services/update_record_from_harvest_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe UpdateRecordFromHarvest do
         expect(record.internal_identifier).to eq 'end-to-end_exemplar_TEST_record-20190306T1140'
       end
 
+      it 'sets the record_type if given' do
+        record = UpdateRecordFromHarvest.new(payload.merge('record_type' => 1)).call
+        expect(record.record_type).to eq 1
+      end
+
+      it 'leaves the default record_type if not given' do
+        expect(record.record_type).to eq 0
+      end
+
       it 'sets single value fields on the primary_fragment' do
         expect(record.display_collection).to eq 'DNZ end to end test display_collection'
         expect(record.title).to eq 'DNZ end to end test title'


### PR DESCRIPTION
[AUTHORITY INDEXING BUG](https://www.pivotaltracker.com/story/show/183450207)

STORY
=====

### Latest info
Since the beginning of (Sj) time, the authorities harvest has made authorities records using this code in the parser
>  attributes :record_type,                                              default: 1

Which wrote that piece of metadata to the head of the mongo record (not in the fragments)
It seems that some part of that process is not working now. That metadata is not writing and all records end up with the default record_type of 0.


### Problem
1. How come this doesnt find anything (based on the broader term text query)
https://api.staging.digitalnz.org/records.json?api_key=v0aORgQAmQDSPtOJzMGI&record_type=1&per_page=100&fields=tag,title,dc_identifier,internal_identifier,authorities&ignore_metrics=true&text=broader_term_id_im:%22-353070%22
2. When there is a record that should be found
https://api.staging.digitalnz.org/records/51043968.json?api_key=v0aORgQAmQDSPtOJzMGI&fields=verbose,attachments,authorities,locations
3. That was apparently indexed `"[2022-10-04 10:56:38 +1300] [27209/1] 1 to be indexed: [51043968]"`

### Expected behaviour
1. While this older example of the same thing works
https://api.staging.digitalnz.org/records.json?api_key=v0aORgQAmQDSPtOJzMGI&record_type=1&per_page=100&fields=id,tag,title,dc_identifier,internal_identifier,authorities&ignore_metrics=true&text=broader_term_id_im:%22-335816%22
2. Finds this record based on equivalent authority metadata
https://api.staging.digitalnz.org/records/36900567.json?api_key=v0aORgQAmQDSPtOJzMGI&fields=verbose,attachments,authorities,locations


**Notes**
- Sort of feel like I'm doing something dumb here. But not sure what.
- Initially noticed when records started loosing all their broader/narrower terms linked in the left hand side panel. eg https://national-library.staging.natlib.nz/records/35672736 should have loads
