### PR TITLE
[bug] Editing Text in stories does not prompt remoderation status

### DIFF
--- a/app/controllers/supplejack_api/story_items_controller.rb
+++ b/app/controllers/supplejack_api/story_items_controller.rb
@@ -40,6 +40,8 @@ module SupplejackApi
           @story.update_attribute(:cover_thumbnail, nil)
         end
 
+        @story.remoderate! if @story.respond_to?(:may_remoderate?) && @story.may_remoderate?
+
         render_json_with json: @item, serializer: StoryItemSerializer
       else
         render_error_with('Failed to update', :bad_request)


### PR DESCRIPTION
[[bug] Editing Text in stories does not prompt remoderation status](https://www.pivotaltracker.com/story/show/184407094)

STORY
=====

Both Staging and Prod

Editing existing text fields, including adding links, does not cause a remoderation flag in digitalnz.org. Altered content is published immediately.

True for text fields in stories (not Story title, description, subjects) plus captions and notes on all Images, and editing (or adding new) metadata on uploaded images (possibly a separate issue).

Steps

Start from existing, accepted story, with text field.
change text field, save
check moderation dashboard, story still flagged “Accepted’
Check front end, story shows new edited content

https://boost.sifterapp.com/issues/9715
