### PR TITLE
fix: Remove drop_dups

### DIFF
--- a/app/models/supplejack_api/support/storable.rb
+++ b/app/models/supplejack_api/support/storable.rb
@@ -17,7 +17,7 @@ module SupplejackApi
         field :record_type,                 type: Integer,      default: 0
 
         index({ status: 1 }, background: true)
-        index({ internal_identifier: 1 }, unique: true, drop_dups: true, background: true)
+        index({ internal_identifier: 1 }, unique: true, background: true)
         index({ record_type: 1 }, background: true)
         index({ record_id: 1 }, unique: true, background: true)
 


### PR DESCRIPTION
- Its been deprecated in MongoDB v 5.1 https://jira.mongodb.org/browse/MONGOID-4576