### PR TITLE
[BUG] EXCLUDE FILTERS FROM FACETS BOOLEAN FIELDS: As an open source user, I want to be able to use the exclude filters from facet feature with boolean fields, so that I can display the correct facet counts to my users. 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       sunspot_solr
       thin
       unicode_utils
-      voight_kampff
+      voight_kampff (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -482,4 +482,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.3.12
+   2.4.9

--- a/app/solr_queries/query_builder/exclude_filters_from_facets.rb
+++ b/app/solr_queries/query_builder/exclude_filters_from_facets.rb
@@ -68,12 +68,12 @@ module QueryBuilder
         search_context.with(facet_name).starting_with(Regexp.last_match(1))
       elsif value.is_a?(Hash) && value.key?(:or)
         search_context.with(facet_name, value[:or])
-      elsif downcased_value == 'true' || downcased_value == 'false'
-        # If Solr receives the string value 'false', 
+      elsif %w[true false].include?(downcased_value)
+        # If Solr receives the string value 'false',
         # it will convert it into the Boolean true, giving the opposite result
         boolean_value = (downcased_value == 'true')
 
-        search_context.with(facet_name, boolean_value)        
+        search_context.with(facet_name, boolean_value)
       else
         # Value is a non-wildcarded string, or an array
         search_context.with(facet_name, value)

--- a/app/solr_queries/query_builder/exclude_filters_from_facets.rb
+++ b/app/solr_queries/query_builder/exclude_filters_from_facets.rb
@@ -62,16 +62,14 @@ module QueryBuilder
       # Necessary to pass search_context in order to generate `with` queries
       wildcard_search_term_regex = /(.+)\*$/ # search term ends in *
 
-      downcased_value = value.downcase
-
       if value =~ wildcard_search_term_regex
         search_context.with(facet_name).starting_with(Regexp.last_match(1))
       elsif value.is_a?(Hash) && value.key?(:or)
         search_context.with(facet_name, value[:or])
-      elsif %w[true false].include?(downcased_value)
+      elsif %w[true false].include?(value)
         # If Solr receives the string value 'false',
         # it will convert it into the Boolean true, giving the opposite result
-        boolean_value = (downcased_value == 'true')
+        boolean_value = (value == 'true')
 
         search_context.with(facet_name, boolean_value)
       else

--- a/spec/models/supplejack_api/record_search_spec.rb
+++ b/spec/models/supplejack_api/record_search_spec.rb
@@ -511,7 +511,7 @@ module SupplejackApi
             facets: 'nz_citizen',
             exclude_filters_from_facets: 'true'
           ).execute_solr_search
-          
+
           expect(@session).to have_search_params(:with, proc do
             all_of do
               with(:nz_citizen, false)
@@ -530,7 +530,6 @@ module SupplejackApi
             category_filter = with(:category, %w[Images])
             facet(:category, exclude: category_filter)
           }
-          
         end
 
         it 'applies filters that are given which are not facets' do

--- a/spec/models/supplejack_api/record_search_spec.rb
+++ b/spec/models/supplejack_api/record_search_spec.rb
@@ -429,7 +429,6 @@ module SupplejackApi
             facets: 'name, address',
             exclude_filters_from_facets: 'true'
           ).execute_solr_search
-
           expect(@session).to have_search_params(:facet) {
             name_filter = with(:name, names)
             facet(:name, exclude: name_filter)
@@ -506,6 +505,20 @@ module SupplejackApi
           }
         end
 
+        it 'handles Boolean facets correctly' do
+          RecordSearch.new(
+            and: { nz_citizen: 'false' },
+            facets: 'nz_citizen',
+            exclude_filters_from_facets: 'true'
+          ).execute_solr_search
+          
+          expect(@session).to have_search_params(:with, proc do
+            all_of do
+              with(:nz_citizen, false)
+            end
+          end)
+        end
+
         it 'applies filters that are given as strings via the URL correctly' do
           RecordSearch.new(
             and: { category: %w[Images] },
@@ -517,6 +530,7 @@ module SupplejackApi
             category_filter = with(:category, %w[Images])
             facet(:category, exclude: category_filter)
           }
+          
         end
 
         it 'applies filters that are given which are not facets' do

--- a/supplejack_api.gemspec
+++ b/supplejack_api.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machine'
   s.add_dependency 'thin'
   s.add_dependency 'unicode_utils'
-  s.add_dependency 'voight_kampff'
+  s.add_dependency 'voight_kampff', '~> 1.0'
 
   # # Adding sunspot_solr so app has access to sunspot:solr rake tasks
   s.add_dependency 'activeresource'


### PR DESCRIPTION
**Acceptance Criteria**
- Exclude filters from facets functionality works on Boolean fields. 
- Inform PVM team and resolve Github issue. 

**Notes**
- https://github.com/DigitalNZ/supplejack_api/issues/334


References issue #334 