### PR TITLE
MODERATION HISTORY: As a dashboard moderator, I want to know when a stories moderation status was changed, so that I understand if a story was last changed by a user or the system. 

### DIFF
--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -56,24 +56,12 @@ module SupplejackApi
       @current_user ||= User.find_by_auth_token(current_auth_token)
     end
 
-    def current_story_user
-      @current_story_user ||= User.find_by_auth_token(params[:user_key])
-    end
-
     def prevent_anonymous!
       return unless RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
 
       render json: {
         errors: I18n.t('errors.prevent_anonymous')
       }, status: :forbidden
-    end
-
-    def story_user_check
-      if params[:user_key]
-        render_error_with(I18n.t('errors.user_not_found', key: params[:user_key]), :not_found) unless current_story_user
-      else
-        render_error_with(I18n.t('errors.user_key_missing'), :bad_request)
-      end
     end
 
     def render_error_with(message, code)


### PR DESCRIPTION
[MODERATION HISTORY: As a dashboard moderator, I want to know when a stories moderation status was changed, so that I understand if a story was last changed by a user or the system. ](https://www.pivotaltracker.com/story/show/184644590)

STORY
=====

**Acceptance Criteria**
- A story moderator is able to see a history of moderation changes for a story. 
- moderator can see which user has made the changes

**Impacts**
- Should greatly improve our ability to troubleshoot issues but also make our assurance of the dashboard as a record of transactions more robust.

**Questions**
- action, person, date?
- Rails logging library, library patterns.
- Show activity log in time order
- How long to keep log vs how much we show on front end?

**Risks**
- Storing lots of history information could make the size of the story much larger. We should just store what we think would be most useful.

**Notes**
- This has come from a confusing meteor where a whole range of stories had their last modified values updated and we were unable to tell from the Dashboard why. 
- See https://www.pivotaltracker.com/story/show/184608897 for more information. 
- This doesn't cover story changes, only changes to the moderation status
- Add a calendar alert to review size of the log in two months
