### PR TITLE
ANONYMOUS API KEY USAGE: As Dan, I want to see a warning when the anonymous api key account nears its daily limit, so that I can take any necessary action.

### DIFF
--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -27,7 +27,11 @@ module SupplejackApi
 
       if current_user
         if current_user.over_limit?
-          error_message = I18n.t('users.reached_limit')
+          if RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
+            error_message = I18n.t('users.anonymous_reached_limit')
+          else
+            error_message = I18n.t('users.reached_limit')
+          end
         else
           current_user.update_tracked_fields(request)
           current_user.update_daily_activity(request)

--- a/app/controllers/supplejack_api/supplejack_application_controller.rb
+++ b/app/controllers/supplejack_api/supplejack_application_controller.rb
@@ -27,11 +27,11 @@ module SupplejackApi
 
       if current_user
         if current_user.over_limit?
-          if RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
-            error_message = I18n.t('users.anonymous_reached_limit')
-          else
-            error_message = I18n.t('users.reached_limit')
-          end
+          error_message = if RecordSchema.roles[current_user.role.to_sym].try(:anonymous)
+                            I18n.t('users.anonymous_reached_limit')
+                          else
+                            I18n.t('users.reached_limit')
+                          end
         else
           current_user.update_tracked_fields(request)
           current_user.update_daily_activity(request)

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -6,6 +6,7 @@
 en:
   users:
     reached_limit: You have reached your maximum number of api requests today
+    anonymous_reached_limit: The anonymous key has reached the maximum number of API requests for today
     invalid_token: Invalid API Key
     blank_token: Please provide a API Key
     title: Users


### PR DESCRIPTION
**Acceptance Criteria**

- Anonymous users receive a useful response from the API when the Anonymous key has reached it's limit