### PR TITLE
[BUG] STORY COVER THUMBNAILS SYNC ISSUE: As an API consumer, I want the cover thumbnail of the story to be up to date with the record that it is referencing so that users get the cover thumbnail that they are expecting.

### DIFF
--- a/app/models/supplejack_api/concerns/privacyable.rb
+++ b/app/models/supplejack_api/concerns/privacyable.rb
@@ -11,7 +11,6 @@ module SupplejackApi
         field :privacy, type: String,   default: 'public'
 
         validates :privacy, inclusion: { in: %w[public hidden private] }
-        before_validation :set_default_privacy
 
         # can't add this scope without breaking the model
         # it must be an existing method in Mongoid


### PR DESCRIPTION
[[BUG] STORY COVER THUMBNAILS SYNC ISSUE: As an API consumer, I want the cover thumbnail of the story to be up to date with the record that it is referencing so that users get the cover thumbnail that they are expecting.](https://www.pivotaltracker.com/story/show/186908592)

STORY
=====

**Acceptance Criteria**
- A story's cover thumbnail is in sync with the record that it is referencing. 
- Existing stories are fixed.
- API responses are staying the same

**Notes**
https://www.pivotaltracker.com/story/show/186872083

**Risks**
- The Topic Explorer uses stories, we could break it

