### PR TITLE
Allow multi value fields to not be merged via the schema

### DIFF
--- a/app/models/supplejack_api/schema_definition.rb
+++ b/app/models/supplejack_api/schema_definition.rb
@@ -7,7 +7,7 @@ module SupplejackApi
     SCHEMA_METHODS = %i[string integer datetime boolean latlon text].freeze
     ALLOWED_ATTRIBUTES = {
       field: %i[type search_value search_boost multi_value facet_method search_as store
-                solr_name namespace namespace_field default_value date_format],
+                solr_name namespace namespace_field default_value date_format merge_as_single_value],
       group: %i[fields includes],
       role: %i[default field_restrictions record_restrictions admin harvester anonymous],
       namespace: [:url],

--- a/app/models/supplejack_api/support/fragment_helpers.rb
+++ b/app/models/supplejack_api/support/fragment_helpers.rb
@@ -44,7 +44,7 @@ module SupplejackApi
 
         # rubocop:disable Layout/LineLength
         new_fragment_attributes = fragment_class.mutable_fields.each_with_object({}) do |(field_name, field_type), attributes|
-          if field_type == Array
+          if field_type == Array && RecordSchema.fields[field_name.to_sym]&.merge_as_single_value.blank?
             attributes[field_name] = []
 
             sorted_fragments.each do |fragment|

--- a/spec/dummy/app/supplejack_api/record_schema.rb
+++ b/spec/dummy/app/supplejack_api/record_schema.rb
@@ -25,6 +25,8 @@ class RecordSchema
   string   :creator,               multi_value: true, search_as: [:filter, :fulltext],       namespace: :dc
   string   :contributing_partner,  multi_value: true, search_as: [:fulltext],                namespace: :dc
   string   :subject,               multi_value: true, search_as: [:filter, :fulltext, :mlt], namespace: :dc
+  string   :empowering_provisions, multi_value: true, search_as: [:filter], merge_as_single_value: true
+  string   :multi_value_merge, multi_value: true, search_as: [:filter], merge_as_single_value: false
 
   latlon(:lat_lng) do
     search_as [:filter]

--- a/spec/models/supplejack_api/support/fragment_helpers_spec.rb
+++ b/spec/models/supplejack_api/support/fragment_helpers_spec.rb
@@ -145,35 +145,35 @@ module SupplejackApi
             context 'merge_as_single_value: true' do
               before(:each) do
                 official_fragment = build(:record_fragment,
-                                 empowering_provisions: ['a', 'b', 'c'],
-                                 multi_value_merge: ['1', '2', '3'],
-                                 source_id: 'official',
-                                 priority: -999)
-                
+                                          empowering_provisions: %w[a b c],
+                                          multi_value_merge: %w[1 2 3],
+                                          source_id: 'official',
+                                          priority: -999)
+
                 source_fragment = build(:record_fragment,
-                                 empowering_provisions: ['d', 'e', 'f'],
-                                 multi_value_merge: ['4', '5', '6'],
-                                 source_id: 'source',
-                                 priority: -998)
+                                        empowering_provisions: %w[d e f],
+                                        multi_value_merge: %w[4 5 6],
+                                        source_id: 'source',
+                                        priority: -998)
 
                 record.fragments << official_fragment
                 record.fragments << source_fragment
                 record.reload.save!
               end
-              
+
               it 'should only display the highest priority multi value field when merge_as_single_value: true' do
-                expect(record.merged_fragment.empowering_provisions).to eq ['a', 'b', 'c']
+                expect(record.merged_fragment.empowering_provisions).to eq %w[a b c]
               end
 
               it 'falls back to the second highest priority if the highest priority does not have a value' do
                 record.fragments.find_by(source_id: 'official').empowering_provisions = nil
                 record.save
 
-                expect(record.merged_fragment.empowering_provisions).to eq ['d', 'e', 'f']
+                expect(record.merged_fragment.empowering_provisions).to eq %w[d e f]
               end
 
-              it 'does not merge array fields as single values when they are not specified to do so in the RecordSchema' do
-                expect(record.merged_fragment.multi_value_merge).to eq ['1', '2', '3', '4', '5', '6']
+              it 'does not merge array fields as single values when they are not specified in the RecordSchema' do
+                expect(record.merged_fragment.multi_value_merge).to eq %w[1 2 3 4 5 6]
               end
             end
           end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -119,6 +119,8 @@ RSpec.describe 'Records Endpoints', type: :request do
                         'rights' => record.rights,
                         'status' => record.status,
                         'subject' => record.subject,
+                        'empowering_provisions' => [],
+                        'multi_value_merge' => [],
                         'sort_date' => nil,
                         'sort_date_str' => nil,
                         'tag' => record.tag,


### PR DESCRIPTION
If a multi value field is marked as `merge_as_single_value` it only take the value from the highest priority fragment rather than combining all of the array fields with the same name from multiple fragments. 

PCO needs this as there are official and source fragments which have an array field called `empowering_provisions`. We want to store this data as an Array as it is multivalue but when the fragments are merged we want to show either the official if it is present or the source if the official is not present. We do not want to show both. 

