### PR TITLE
INDEXING DROPPING RECORDS: As Dan I want all records to be reliably indexed after being updated, so that a harvests changes are accurately reflected in the API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,11 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*'
 
+Rails/Output:
+  Exclude:
+    # that's only used in a rake task
+    - lib/supplejack_api/index_processor.rb
+
 # Currently broken due to a bug when autocorrecting
 # https://github.com/bbatsov/rubocop/issues/3510
 Style/SafeNavigation:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,4 +497,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.9
+   2.5.18

--- a/app/controllers/supplejack_api/harvester/sources_controller.rb
+++ b/app/controllers/supplejack_api/harvester/sources_controller.rb
@@ -3,17 +3,6 @@
 module SupplejackApi
   module Harvester
     class SourcesController < BaseController
-      def create
-        if source_params[:_id].present?
-          @source = Source.find_or_initialize_by(_id: source_params[:_id])
-          @source.update(source_params)
-        else
-          @source = Source.create(source_params)
-        end
-
-        render json: @source
-      end
-
       def index
         @sources = params[:source].blank? ? Source.all : Source.where(source_params)
         @sources = @sources.order_by(params[:order_by] => 'desc') if params[:order_by].present?
@@ -24,6 +13,17 @@ module SupplejackApi
 
       def show
         @source = Source.find(params[:id])
+        render json: @source
+      end
+
+      def create
+        if source_params[:_id].present?
+          @source = Source.find_or_initialize_by(_id: source_params[:_id])
+          @source.update(source_params)
+        else
+          @source = Source.create(source_params)
+        end
+
         render json: @source
       end
 
@@ -52,7 +52,9 @@ module SupplejackApi
 
       def source_params
         @source_params ||= begin
-          source_params = params.require(:source).permit(:name, :_id, :id, :source_id, :status, :status_updated_by).to_h
+          source_params = params.require(:source).permit(
+            :name, :_id, :id, :source_id, :status, :harvesting, :status_updated_by
+          ).to_h
           partner_params = params.permit(:partner_id).to_h
           source_params.merge(partner_params)
         end

--- a/app/models/supplejack_api/source.rb
+++ b/app/models/supplejack_api/source.rb
@@ -10,6 +10,7 @@ module SupplejackApi
     store_in collection: 'sources', client: 'strong'
 
     field :source_id,            type: String
+    field :harvesting,           type: Boolean, default: false
     field :status,               type: String, default: 'active'
     field :status_updated_by,    type: String
     field :status_updated_at,    type: DateTime

--- a/app/services/batch_index_records.rb
+++ b/app/services/batch_index_records.rb
@@ -27,13 +27,13 @@ class BatchIndexRecords
   # Call Sunspot index in the array provided, if failure,
   # retry each record individually to be indexed and log errors
   def retry_index_records(records)
-    p 'BatchIndexRecords - INDEXING batch has raised an exception - retrying individual records'
+    puts 'BatchIndexRecords - INDEXING batch has raised an exception - retrying individual records'
 
     records.each { |record| index_individual_record(record) }
   end
 
   def index_individual_record(record)
-    p "BatchIndexRecords - INDEXING: #{record.record_id}"
+    puts "BatchIndexRecords - INDEXING: #{record.record_id}"
 
     Sunspot.index record
   rescue StandardError => e

--- a/lib/supplejack_api/index_processor.rb
+++ b/lib/supplejack_api/index_processor.rb
@@ -56,9 +56,13 @@ module SupplejackApi
     end
 
     def source_ids
-      return SupplejackApi::AbstractJob.active_job_source_ids if ENV['WORKER_HOST'].present?
+      # coming from the worker
+      worker_source_ids = []
+      worker_source_ids = AbstractJob.active_job_source_ids if ENV['WORKER_HOST'].present?
+      # coming from the harvester
+      api_source_ids = Source.where(harvesting: true)
 
-      []
+      (api_source_ids.map(&:source_id) + worker_source_ids).uniq
     end
 
     # rubocop:disable Rails/Output

--- a/lib/supplejack_api/index_processor.rb
+++ b/lib/supplejack_api/index_processor.rb
@@ -65,13 +65,11 @@ module SupplejackApi
       (api_source_ids.map(&:source_id) + worker_source_ids).uniq
     end
 
-    # rubocop:disable Rails/Output
     def log(str, prefix = '')
       return if Rails.env.test?
 
       prefix = "[#{Time.current}] [#{Process.pid}/#{Process.ppid}] " if prefix.present?
-      p "#{prefix}#{str}"
+      puts "#{prefix}#{str}"
     end
-    # rubocop:enable Rails/Output
   end
 end

--- a/spec/lib/supplejack_api/index_processor_spec.rb
+++ b/spec/lib/supplejack_api/index_processor_spec.rb
@@ -30,5 +30,19 @@ RSpec.describe SupplejackApi::IndexProcessor do
 
       expect(SupplejackApi::Record.ready_for_indexing.count).to eq 0
     end
+
+    it 'does not index records related to harvesting source_id' do
+      create(:record, fragments: [build(:record_fragment, source_id: 'hello')])
+      create(:source, source_id: 'hello', harvesting: true)
+
+      expect(Sunspot).to receive(:index).with(active_records)
+      expect(SupplejackApi::Record.ready_for_indexing.count).to eq 6
+
+      sleep 5 # required as the index processor picks up records created 5 seconds ago
+
+      described_class.new.call
+
+      expect(SupplejackApi::Record.ready_for_indexing.count).to eq 1
+    end
   end
 end


### PR DESCRIPTION
[INDEXING DROPPING RECORDS: As Dan I want all records to be reliably indexed after being updated, so that a harvests changes are accurately reflected in the API](https://www.pivotaltracker.com/story/show/187794086)

STORY
=====

**Acceptance Criteria**
- All records updated in a harvest are indexed correctly in solr

**Risks**
- Is this wider than just new SJ enrichments?!

**Problem**
- After a harvest and enrichment:
 - all records get their metadata updated correctly
 - a handful of records fail to be indexed and still appear in search for previous metadata
 - those records id's were listed in the array to be indexed
 - those records are able to be indexed (eg if you do them manually they work)
- First test 12 / 287 missed
- Second test 2 / 476 missed
- Third test 108 / 287 missed

**Dan's Theory**
- New SJ is not updating the "Active source ids"
`"Active source ids [\"hawkesbayknowledgebank\", \"nlnzcat_alma\"]"`
This is used to ensure the indexing doesn't start picking up records until they have been finished updating/harvesting/enriching. Implemented in this story https://www.pivotaltracker.com/story/show/181472631

**Notes**
- There has been a lot of work lately in this area of our system:
 - https://www.pivotaltracker.com/story/show/182068934
 - Solr and Mongo upgrades
 - https://www.pivotaltracker.com/story/show/187598418
- Does not appear to be happening in old SJ


**Tests**
- Run an enrichment where the enrichment transformation adds bulk value to all records
- Query that source_id + the bulk added value
- Re-run the enrichment with a modified value
- Re-check the query and see a few left over in solr, but note that their metadata has been updated (shows new value, but is returned in solr query for old value)
- eg this shows 108 records that failed to be indexed :( https://api.staging.digitalnz.org/records.json?&text=source_id_s:niwa&without[subject]=testingEnrichmentIndexing1&per_page=20&fields=id,subject
- Modify the subject field and rerun https://harvester.digitalnz.org/pipelines/27/harvest_definitions/49/transformation_definitions/50

**Impacts**
- Indexing has to be reliable!
