### PR TITLE
Missing index for enrichments

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -79,9 +79,9 @@ module SupplejackApi
 
         page = search_options_params[:page].to_i
 
-        @records = SupplejackApi::Record
-                   .where(search_params.to_hash)
-                   .page(page).per(20).hint(hints)
+        @records = SupplejackApi::Record.order_by(%i[created_at asc])
+                                        .where(search_params.to_hash)
+                                        .page(page).per(20).hint(hints)
 
         if @records.present?
           render json: @records,

--- a/app/models/supplejack_api/support/storable.rb
+++ b/app/models/supplejack_api/support/storable.rb
@@ -20,6 +20,8 @@ module SupplejackApi
         index({ internal_identifier: 1 }, unique: true, background: true)
         index({ record_type: 1 }, background: true)
         index({ record_id: 1 }, unique: true, background: true)
+        index({ "fragments.source_id": 1, status: 1 }, unique: true, background: true)
+        index({ index_updated: 1, "fragments.source_id": 1, status: 1 }, unique: true, background: true)
 
         def self.build_model_fields
           return if RecordSchema.model_fields.blank?

--- a/app/models/supplejack_api/support/storable.rb
+++ b/app/models/supplejack_api/support/storable.rb
@@ -20,6 +20,7 @@ module SupplejackApi
         index({ internal_identifier: 1 }, unique: true, background: true)
         index({ record_type: 1 }, background: true)
         index({ record_id: 1 }, unique: true, background: true)
+        index({ created_at: 1 }, unique: true, background: true)
         index({ "fragments.source_id": 1, status: 1 }, unique: true, background: true)
         index({ index_updated: 1, "fragments.source_id": 1, status: 1 }, unique: true, background: true)
 

--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -259,9 +259,11 @@ module SupplejackApi
       describe 'GET index' do
         let!(:records) { create_list(:record_with_fragment, 25) }
         let(:where_params) { ActionController::Parameters.new('fragments.job_id': records.first.job_id).permit! }
+        let(:order_by) { double(:order_by) }
 
         it 'returns object with records based on search params' do
-          expect(Record).to receive(:where).with(where_params).and_call_original
+          expect(SupplejackApi::Record).to receive(:order_by).and_return(order_by)
+          expect(order_by).to receive(:where).with(where_params).and_return(SupplejackApi::Record)
 
           get :index, params: {
             search: { 'fragments.job_id': records.first.job_id },
@@ -341,6 +343,16 @@ module SupplejackApi
 
           get :index, params: {
             search: { 'fragments.source_id': records.first.source_id },
+            search_options: { page: 1 },
+            api_key: harvester.api_key
+          }
+        end
+
+        it 'order results by created_at ascending' do
+          expect(SupplejackApi::Record).to receive(:order_by).with(%i[created_at asc]).and_call_original
+
+          get :index, params: {
+            search: { 'fragments.job_id': records.first.job_id },
             search_options: { page: 1 },
             api_key: harvester.api_key
           }


### PR DESCRIPTION
- Add a sorting to the records#index endpoint so that items are sorted in a way that new items are added at the end of the list.
- Added the following indexes:
 - created_at
 - source_id + status
 - source_id + status + index_updated_at