### PR TITLE
feat(specify-enrichment-fields): Allow specifying particular fields from the Enrichment to prevent returning unnecessary fields

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -45,10 +45,8 @@ module SupplejackApi
 
         render json: {
           status: :failed,
-          exception_class: e.class.to_s,
-          message: e.message,
-          backtrace: e.backtrace,
-          raw_data: @record.try(:to_json),
+          exception_class: e.class.to_s, message: e.message,
+          backtrace: e.backtrace, raw_data: @record.try(:to_json),
           record_id: params[:id]
         }
       end
@@ -85,12 +83,9 @@ module SupplejackApi
 
         if @records.present?
           render json: @records,
-                 adapter: :json,
-                 each_serializer: self.class.record_serializer_class,
-                 fields: params[:fields],
-                 include: record_includes,
-                 root: 'records',
-                 meta: { page:, total_pages: @records.total_pages }
+                 adapter: :json, each_serializer: self.class.record_serializer_class,
+                 fields: params[:fields], include: record_includes,
+                 root: 'records', meta: { page:, total_pages: @records.total_pages }
         else
           head :no_content
         end
@@ -106,7 +101,7 @@ module SupplejackApi
 
       def record_includes
         return params[:record_includes] if params[:record_includes].present?
-          
+
         self.class.record_serializer_includes
       end
 

--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -87,7 +87,8 @@ module SupplejackApi
           render json: @records,
                  adapter: :json,
                  each_serializer: self.class.record_serializer_class,
-                 include: self.class.record_serializer_includes,
+                 fields: params[:fields],
+                 include: record_includes,
                  root: 'records',
                  meta: { page:, total_pages: @records.total_pages }
         else
@@ -101,6 +102,12 @@ module SupplejackApi
 
       def self.record_serializer_includes
         [:fragments]
+      end
+
+      def record_includes
+        return params[:record_includes] if params[:record_includes].present?
+          
+        self.class.record_serializer_includes
       end
 
       private

--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -368,8 +368,8 @@ module SupplejackApi
           body = JSON.parse(response.body)
           record = body['records'][0]
 
-          RecordSchema.fields.each do |name, definition|
-            expect(record.has_key?(name.to_s)).to eq true
+          RecordSchema.fields.each_key do |name|
+            expect(record.key?(name.to_s)).to eq true
           end
         end
 
@@ -378,12 +378,12 @@ module SupplejackApi
             search: { 'fragments.job_id': records.first.job_id },
             search_options: { page: 1 },
             api_key: harvester.api_key,
-            fields: ['id'],
-          } 
+            fields: ['id']
+          }
 
           body = JSON.parse(response.body)
 
-          expect(body['records'][0].has_key?('internal_identifier')).to eq false
+          expect(body['records'][0].key?('internal_identifier')).to eq false
         end
 
         it 'returns the all of the record includes by default' do
@@ -393,12 +393,12 @@ module SupplejackApi
             api_key: harvester.api_key,
             fields: ['id'],
             record_includes: []
-          }  
+          }
 
           body = JSON.parse(response.body)
 
           body['records'].each do |record|
-            expect(record.has_key?('fragments')).to eq true
+            expect(record.key?('fragments')).to eq true
           end
         end
 
@@ -414,7 +414,7 @@ module SupplejackApi
           body = JSON.parse(response.body)
 
           body['records'].each do |record|
-            expect(record.has_key?('fragments')).to eq false
+            expect(record.key?('fragments')).to eq false
           end
         end
       end

--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -357,6 +357,66 @@ module SupplejackApi
             api_key: harvester.api_key
           }
         end
+
+        it 'returns all fields when the fields parameter is missing' do
+          get :index, params: {
+            search: { 'fragments.job_id': records.first.job_id },
+            search_options: { page: 1 },
+            api_key: harvester.api_key
+          }
+
+          body = JSON.parse(response.body)
+          record = body['records'][0]
+
+          RecordSchema.fields.each do |name, definition|
+            expect(record.has_key?(name.to_s)).to eq true
+          end
+        end
+
+        it 'returns fields that have been asked for' do
+          get :index, params: {
+            search: { 'fragments.job_id': records.first.job_id },
+            search_options: { page: 1 },
+            api_key: harvester.api_key,
+            fields: ['id'],
+          } 
+
+          body = JSON.parse(response.body)
+
+          expect(body['records'][0].has_key?('internal_identifier')).to eq false
+        end
+
+        it 'returns the all of the record includes by default' do
+          get :index, params: {
+            search: { 'fragments.job_id': records.first.job_id },
+            search_options: { page: 1 },
+            api_key: harvester.api_key,
+            fields: ['id'],
+            record_includes: []
+          }  
+
+          body = JSON.parse(response.body)
+
+          body['records'].each do |record|
+            expect(record.has_key?('fragments')).to eq true
+          end
+        end
+
+        it 'only returns requested includes when provided' do
+          get :index, params: {
+            search: { 'fragments.job_id': records.first.job_id },
+            search_options: { page: 1 },
+            api_key: harvester.api_key,
+            fields: ['id'],
+            record_includes: ['nothing']
+          }
+
+          body = JSON.parse(response.body)
+
+          body['records'].each do |record|
+            expect(record.has_key?('fragments')).to eq false
+          end
+        end
       end
     end
 


### PR DESCRIPTION
A good example is if you have a fulltext field that you do not need for the enrichment, it gets returned anyway and takes up space in the filesystem and slows down the response. Especially if it is in the merged fragment as well as an embedded fragment.