### PR TITLE
Always return the id field, even when it hasnt asked for when asking for certain fields, as it is required for enrichments to work

### DIFF
--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -10,8 +10,7 @@ module SupplejackApi
       rescue StandardError => e
         Rails.logger.error "Fail to process record #{@record&.record_id}: #{e.inspect}"
         render json: {
-          status: :failed, exception_class: e.class.to_s,
-          message: e.message, backtrace: e.backtrace,
+          status: :failed, exception_class: e.class.to_s, message: e.message, backtrace: e.backtrace,
           raw_data: @record&.attributes, record_id: @record&.record_id
         }
       end
@@ -44,10 +43,8 @@ module SupplejackApi
         Rails.logger.error "Fail to set deleted status to record #{@record}: #{e.inspect}"
 
         render json: {
-          status: :failed,
-          exception_class: e.class.to_s, message: e.message,
-          backtrace: e.backtrace, raw_data: @record.try(:to_json),
-          record_id: params[:id]
+          status: :failed, exception_class: e.class.to_s, message: e.message,
+          backtrace: e.backtrace, raw_data: @record.try(:to_json), record_id: params[:id]
         }
       end
 
@@ -92,7 +89,7 @@ module SupplejackApi
       end
 
       def fields
-        params[:fields] << "id"
+        params[:fields] << 'id'
       end
 
       def self.record_serializer_class

--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -60,8 +60,7 @@ module SupplejackApi
         @record = SupplejackApi::Record.where(record_id: params[:id]).first
 
         if @record.present?
-          render json: @record,
-                 serializer: self.class.record_serializer_class
+          render json: @record, serializer: self.class.record_serializer_class
         else
           head :no_content
         end
@@ -89,6 +88,8 @@ module SupplejackApi
       end
 
       def fields
+        return nil if params[:fields].blank?
+
         params[:fields] << 'id'
       end
 

--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -84,11 +84,15 @@ module SupplejackApi
         if @records.present?
           render json: @records,
                  adapter: :json, each_serializer: self.class.record_serializer_class,
-                 fields: params[:fields], include: record_includes,
+                 fields:, include: record_includes,
                  root: 'records', meta: { page:, total_pages: @records.total_pages }
         else
           head :no_content
         end
+      end
+
+      def fields
+        params[:fields] << "id"
       end
 
       def self.record_serializer_class

--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -380,7 +380,7 @@ module SupplejackApi
             api_key: harvester.api_key,
             fields: ['internal_identifier']
           }
-          
+
           body = JSON.parse(response.body)
 
           expect(body['records'][0].key?('id')).to eq true

--- a/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
+++ b/spec/controllers/supplejack_api/harvester/records_controller_spec.rb
@@ -373,6 +373,20 @@ module SupplejackApi
           expect(body['records'][0].key?('internal_identifier')).to eq false
         end
 
+        it 'always includes the id field, even when it hasnt been asked for' do
+          get :index, params: {
+            search: { 'fragments.job_id': records.first.job_id },
+            search_options: { page: 1 },
+            api_key: harvester.api_key,
+            fields: ['internal_identifier']
+          }
+          
+          body = JSON.parse(response.body)
+
+          expect(body['records'][0].key?('id')).to eq true
+          expect(body['records'][0].key?('internal_identifier')).to eq true
+        end
+
         it 'returns the all of the record includes by default' do
           get :index, params: {
             search: { 'fragments.job_id': records.first.job_id },


### PR DESCRIPTION
The id is saved to the filesystem in the harvester and used to post that record back to the API. 