### PR TITLE
Create records in parallel when the create_batch endpoint is called

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 
 gem 'codeclimate_diff', github: 'boost/codeclimate_diff'
 
+gem 'parallel'
 # we can't add a github repository to the gemspec
 # I'm waiting to know why we use the github version instead of the tag
 gem 'rsolr', '< 2.6.0' # sunspot 2.4.0 has a bug on rsolr 2.6.0

--- a/app/controllers/supplejack_api/harvester/records_controller.rb
+++ b/app/controllers/supplejack_api/harvester/records_controller.rb
@@ -16,13 +16,23 @@ module SupplejackApi
       end
 
       def create_batch
-        records = params[:records].each_with_object([]) do |record, array|
-          r = UpdateRecordFromHarvest.new(record['fields'].to_unsafe_h, false, nil, record['required_fragments']).call
-          array.push({ status: 'success', record_id: r.record_id })
-        rescue StandardError => e
-          array.push({ status: 'failed', exception_class: e.class.to_s, message: e.message, backtrace: e.backtrace,
-                       raw_data: r&.attributes, record_id: r&.record_id })
-          next
+        records = Parallel.map(params[:records], in_threads: 8) do |record|
+          begin
+            r = UpdateRecordFromHarvest.new(record['fields'].to_unsafe_h, false, nil, record['required_fragments']).call
+            {
+              status: 'success',
+              record_id: r.record_id
+            }
+          rescue StandardError => e
+            {
+              status: 'failed',
+              exception_class: e.class.to_s,
+              message: e.message,
+              backtrace: e.backtrace,
+              raw_data: r&.attributes,
+              record_id: r&.record_id
+            }
+          end
         end
 
         render json: records


### PR DESCRIPTION
The create_batch endpoint can take a really long time to process big batches sequentially.

Given none of the records actually need to interact with each other is seems prudent to process the records in parallel and let all their overheads melt away.

NOTE: This is predicated on the order of the processing not mattering as well, which I don't believe it should. This change is also likely to increase pressure on the persistence layer.